### PR TITLE
Ability to ignore elements when matching by body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Next Release
+- Improvements to censoring
+  - Ability to define censored elements individually, with per-element case sensitivity
+- Improvements to matching
+  - Ability to ignore certain elements when matching by body
+
 ## v0.2.0 (2022-05-31)
 
 - Enhance censoring to work on nested data

--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ NOTE: Censors can only be applied to JSON request and response bodies. Attemptin
 import com.easypost.easyvcr;
 import com.easypost.easyvcr.AdvancedSettings;
 import com.easypost.easyvcr.Cassette;
+import com.easypost.easyvcr.CensorElement;
 import com.easypost.easyvcr.Censors;
 import com.easypost.easyvcr.Mode;
 import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpsURLConnection;
 import com.easypost.easyvcr.clients.httpurlconnection.RecordableURL;
+
+import java.util.ArrayList;
 
 public class Example {
     public static void main(String[] args) {
@@ -110,9 +113,13 @@ public class Example {
         AdvancedSettings advancedSettings = new AdvancedSettings();
         List<String> headersToCensor = new ArrayList<>();
         headersToCensor.add("Authorization"); // Hide the Authorization header
-        advancedSettings.censors = new Censors().hideHeader(headersToCensor);
+        advancedSettings.censors = new Censors().censorHeadersByKeys(headersToCensor);
+        advancedSettings.censors.censorBodyElements(new ArrayList<>() {{
+            add(new CensorElement("table", true)); // Hide the table element (case-sensitive) in the request and response body
+        }});
         // or
-        advancedSettings.censors = Censors.strict(); // use the built-in strict censoring mode (hides common sensitive data)
+        advancedSettings.censors =
+                Censors.strict(); // use the built-in strict censoring mode (hides common sensitive data)
 
         RecordableURL recordableURL =
                 new RecordableURL("https://www.example.com", cassette, Mode.Replay, advancedSettings);

--- a/src/main/java/com/easypost/easyvcr/CensorElement.java
+++ b/src/main/java/com/easypost/easyvcr/CensorElement.java
@@ -1,0 +1,35 @@
+package com.easypost.easyvcr;
+
+public class CensorElement {
+    /**
+     * The name of the element to censor.
+     */
+    private final String name;
+    /**
+     * Whether the name must match exactly to trigger a censor.
+     */
+    private final boolean caseSensitive;
+
+    /**
+     * Constructor.
+     * @param name The name of the element to censor.
+     * @param caseSensitive Whether the name must match exactly to trigger a censor.
+     */
+    public CensorElement(String name, boolean caseSensitive) {
+        this.name = name;
+        this.caseSensitive = caseSensitive;
+    }
+
+    /**
+     * Return whether the element matches the name, accounting for case sensitivity.
+     * @param key The name to check.
+     * @return True if the element matches the name.
+     */
+    public boolean matches(String key) {
+        if (caseSensitive) {
+            return key.equals(name);
+        } else {
+            return key.equalsIgnoreCase(name);
+        }
+    }
+}

--- a/src/main/java/com/easypost/easyvcr/Censors.java
+++ b/src/main/java/com/easypost/easyvcr/Censors.java
@@ -19,13 +19,9 @@ import java.util.Map;
  */
 public final class Censors {
     /**
-     * The body parameters to censor.
+     * The body elements to censor.
      */
-    private final List<String> bodyParamsToCensor;
-    /**
-     * Whether censor keys are case sensitive.
-     */
-    private final boolean caseSensitive;
+    private final List<CensorElement> bodyElementsToCensor;
     /**
      * The string to replace censored data with.
      */
@@ -33,11 +29,11 @@ public final class Censors {
     /**
      * The headers to censor.
      */
-    private final List<String> headersToCensor;
+    private final List<CensorElement> headersToCensor;
     /**
      * The query parameters to censor.
      */
-    private final List<String> queryParamsToCensor;
+    private final List<CensorElement> queryParamsToCensor;
 
     /**
      * Initialize a new instance of the Censors factory, using default censor string.
@@ -52,21 +48,10 @@ public final class Censors {
      * @param censorString The string to use to censor sensitive information.
      */
     public Censors(String censorString) {
-        this(censorString, false);
-    }
-
-    /**
-     * Initialize a new instance of the Censors factory.
-     *
-     * @param censorString  The string to use to censor sensitive information.
-     * @param caseSensitive Whether to use case sensitive censoring.
-     */
-    public Censors(String censorString, boolean caseSensitive) {
         this.queryParamsToCensor = new ArrayList<>();
-        this.bodyParamsToCensor = new ArrayList<>();
+        this.bodyElementsToCensor = new ArrayList<>();
         this.headersToCensor = new ArrayList<>();
         this.censorText = censorString;
-        this.caseSensitive = caseSensitive;
     }
 
     /**
@@ -85,75 +70,165 @@ public final class Censors {
      */
     public static Censors strict() {
         Censors censors = new Censors();
-        censors.hideHeaders(Statics.DEFAULT_CREDENTIAL_HEADERS_TO_HIDE);
-        censors.hideBodyParameters(Statics.DEFAULT_CREDENTIAL_PARAMETERS_TO_HIDE);
-        censors.hideQueryParameters(Statics.DEFAULT_CREDENTIAL_PARAMETERS_TO_HIDE);
+        censors.hideHeaderKeys(Statics.DEFAULT_CREDENTIAL_HEADERS_TO_HIDE);
+        censors.hideBodyElementKeys(Statics.DEFAULT_CREDENTIAL_PARAMETERS_TO_HIDE);
+        censors.hideQueryParameterKeys(Statics.DEFAULT_CREDENTIAL_PARAMETERS_TO_HIDE);
         return censors;
     }
 
-    /**
-     * Add a rule to censor specified body parameters.
-     * Note: Only top-level pairs can be censored.
-     *
-     * @param parameterKeys Keys of body parameters to censor.
-     * @return This Censors factory.
-     */
-    public Censors hideBodyParameters(List<String> parameterKeys) {
-        bodyParamsToCensor.addAll(parameterKeys);
-        return this;
+    private static List<Object> applyJsonCensors(List<Object> list, String censorText,
+                                                 List<CensorElement> elementsToCensor) {
+        if (list == null || list.size() == 0) {
+            // short circuit if list is null or empty
+            return list;
+        }
+
+        List<Object> censoredList = new ArrayList<>();
+
+        for (Object object : list) {
+            Object value = object;
+            if (Utilities.isDictionary(value)) {
+                // recursively censor inner dictionaries
+                try {
+                    // change the value if can be parsed as a dictionary
+                    value = applyJsonCensors((Map<String, Object>) value, censorText, elementsToCensor);
+                } catch (ClassCastException e) {
+                    // otherwise, skip censoring
+                }
+            } else if (Utilities.isList(value)) {
+                // recursively censor list elements
+                try {
+                    // change the value if can be parsed as a list
+                    value = applyJsonCensors((List<Object>) value, censorText, elementsToCensor);
+                } catch (ClassCastException e) {
+                    // otherwise, skip censoring
+                }
+            }  // either a primitive or null, no censoring needed
+
+            censoredList.add(value);
+        }
+
+        return censoredList;
+
+    }
+
+    private static Map<String, Object> applyJsonCensors(Map<String, Object> dictionary, String censorText,
+                                                        List<CensorElement> elementsToCensor) {
+        if (dictionary == null || dictionary.size() == 0) {
+            // short circuit if dictionary is null or empty
+            return dictionary;
+        }
+
+        Map<String, Object> censoredBodyDictionary = new HashMap<>();
+
+        for (Map.Entry<String, Object> entry : dictionary.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (keyShouldBeCensored(key, elementsToCensor)) {
+                if (value == null) {
+                    // don't need to worry about censoring something that's null
+                    // (don't replace null with the censor string)
+                    continue;
+                } else if (Utilities.isDictionary(value)) {
+                    // replace with empty dictionary
+                    censoredBodyDictionary.put(key, new HashMap<>());
+                } else if (Utilities.isList(value)) {
+                    // replace with empty array
+                    censoredBodyDictionary.put(key, new ArrayList<>());
+                } else {
+                    // replace with censor text
+                    censoredBodyDictionary.put(key, censorText);
+                }
+            } else {
+                if (Utilities.isDictionary(value)) {
+                    // recursively censor inner dictionaries
+                    try {
+                        // change the value if can be parsed as a dictionary
+                        value = applyJsonCensors((Map<String, Object>) value, censorText, elementsToCensor);
+                    } catch (ClassCastException e) {
+                        // otherwise, skip censoring
+                    }
+                } else if (Utilities.isList(value)) {
+                    // recursively censor list elements
+                    try {
+                        // change the value if can be parsed as a list
+                        value = applyJsonCensors((List<Object>) value, censorText, elementsToCensor);
+                    } catch (ClassCastException e) {
+                        // otherwise, skip censoring
+                    }
+                }
+
+                censoredBodyDictionary.put(key, value);
+            }
+        }
+
+        return censoredBodyDictionary;
     }
 
     /**
-     * Add a rule to censor specified header keys.
-     * Note: This will censor the header keys in both the request and response.
+     * Apply censors to a JSON string.
      *
-     * @param headerKeys Keys of headers to censor.
-     * @return This Censors factory.
+     * @param data             The JSON string to censor.
+     * @param censorText       The string to use to censor sensitive information.
+     * @param elementsToCensor The body elements to censor.
+     * @return The censored JSON string.
      */
-    public Censors hideHeaders(List<String> headerKeys) {
-        headersToCensor.addAll(headerKeys);
-        return this;
+    public static String censorJsonData(String data, String censorText, List<CensorElement> elementsToCensor) {
+        Map<String, Object> bodyDictionary;
+        try {
+            bodyDictionary = Serialization.convertJsonToObject(data, Map.class);
+            Map<String, Object> censoredBodyDictionary = applyJsonCensors(bodyDictionary, censorText, elementsToCensor);
+            return censoredBodyDictionary == null ? data : Serialization.convertObjectToJson(censoredBodyDictionary);
+        } catch (Exception ignored) {
+            // body is not a JSON dictionary
+            try {
+                List<Object> bodyList = Serialization.convertJsonToObject(data, List.class);
+                List<Object> censoredBodyList = applyJsonCensors(bodyList, censorText, elementsToCensor);
+                return censoredBodyList == null ? data : Serialization.convertObjectToJson(censoredBodyList);
+            } catch (Exception notJsonData) {
+                throw new JsonParseException("Body is not a JSON dictionary or list");
+            }
+        }
+    }
+
+    private static boolean keyShouldBeCensored(String foundKey, List<CensorElement> elementsToCensor) {
+        return elementsToCensor.stream().anyMatch(queryElement -> queryElement.matches(foundKey));
     }
 
     /**
-     * Add a rule to censor specified query parameters.
+     * Censor the appropriate body elements.
      *
-     * @param parameterKeys Keys of query parameters to censor.
-     * @return This Censors factory.
-     */
-    public Censors hideQueryParameters(List<String> parameterKeys) {
-        queryParamsToCensor.addAll(parameterKeys);
-        return this;
-    }
-
-    /**
-     * Censor the appropriate body parameters.
-     *
-     * @param body String representation of request body to apply censors to.
+     * @param body                 String representation of request body to apply censors to.
+     * @param censorText           The string to use to censor sensitive information.
+     * @param bodyElementsToCensor The body elements to censor.
      * @return Censored string representation of request body.
      */
-    public String censorBodyParameters(String body) {
+    public static String censorBodyParameters(String body, String censorText,
+                                              List<CensorElement> bodyElementsToCensor) {
         if (body == null || body.length() == 0) {
             // short circuit if body is null or empty
             return body;
         }
 
-        if (bodyParamsToCensor.size() == 0) {
+        if (bodyElementsToCensor.size() == 0) {
             // short circuit if there are no censors to apply
             return body;
         }
 
         // TODO: Future different content type support here, only JSON is supported currently
-        return censorJsonBodyParameters(body);
+        return censorJsonData(body, censorText, bodyElementsToCensor);
     }
 
     /**
      * Censor the appropriate headers.
      *
-     * @param headers Map of headers to apply censors to.
+     * @param headers         Map of headers to apply censors to.
+     * @param censorText      The string to use to censor sensitive information.
+     * @param headersToCensor The headers to censor.
      * @return Censored map of headers.
      */
-    public Map<String, List<String>> censorHeaders(Map<String, List<String>> headers) {
+    public static Map<String, List<String>> censorHeaders(Map<String, List<String>> headers, String censorText,
+                                                          List<CensorElement> headersToCensor) {
         if (headers == null || headers.size() == 0) {
             // short circuit if there are no headers to censor
             return headers;
@@ -166,21 +241,25 @@ public final class Censors {
 
         final Map<String, List<String>> headersCopy = new HashMap<>(headers);
 
-        for (String headerKey : headersToCensor) {
-            if (headersCopy.containsKey(headerKey)) {
+        List<String> headerKeys = new ArrayList<>(headersCopy.keySet());
+        for (String headerKey : headerKeys) {
+            if (keyShouldBeCensored(headerKey, headersToCensor)) {
                 headersCopy.put(headerKey, Collections.singletonList(censorText));
             }
         }
+
         return headersCopy;
     }
 
     /**
      * Censor the appropriate query parameters.
      *
-     * @param url Full URL string to apply censors to.
+     * @param url                 Full URL string to apply censors to.
+     * @param censorText          The string to use to censor sensitive information.
+     * @param queryParamsToCensor The query parameters to censor.
      * @return Censored URL string.
      */
-    public String censorQueryParameters(String url) {
+    public static String censorQueryParameters(String url, String censorText, List<CensorElement> queryParamsToCensor) {
         if (url == null || url.length() == 0) {
             // short circuit if url is null
             return url;
@@ -198,9 +277,10 @@ public final class Censors {
             return url;
         }
 
-        for (String parameterKey : queryParamsToCensor) {
-            if (queryParameters.containsKey(parameterKey)) {
-                queryParameters.put(parameterKey, censorText);
+        List<String> queryKeys = new ArrayList<>(queryParameters.keySet());
+        for (String queryKey : queryKeys) {
+            if (keyShouldBeCensored(queryKey, queryParamsToCensor)) {
+                queryParameters.put(queryKey, censorText);
             }
         }
 
@@ -214,117 +294,141 @@ public final class Censors {
         return uri.getScheme() + "://" + uri.getHost() + uri.getPath() + "?" + formattedQueryParameters;
     }
 
-    private List<Object> applyBodyCensors(List<Object> list) {
-        if (list == null || list.size() == 0) {
-            // short circuit if list is null or empty
-            return list;
-        }
-
-        List<Object> censoredList = new ArrayList<>();
-
-        for (Object object : list) {
-            Object value = object;
-            if (Utilities.isDictionary(value)) {
-                // recursively censor inner dictionaries
-                try {
-                    // change the value if can be parsed as a dictionary
-                    value = applyBodyCensors((Map<String, Object>) value);
-                } catch (ClassCastException e) {
-                    // otherwise, skip censoring
-                }
-            } else if (Utilities.isList(value)) {
-                // recursively censor list elements
-                try {
-                    // change the value if can be parsed as a list
-                    value = applyBodyCensors((List<Object>) value);
-                } catch (ClassCastException e) {
-                    // otherwise, skip censoring
-                }
-            }  // either a primitive or null, no censoring needed
-
-            censoredList.add(value);
-        }
-
-        return censoredList;
-
+    /**
+     * Add a rule to censor specified body elements.
+     *
+     * @param elements List of body elements to censor.
+     * @return This Censors factory.
+     */
+    public Censors hideBodyElements(List<CensorElement> elements) {
+        bodyElementsToCensor.addAll(elements);
+        return this;
     }
 
-    private Map<String, Object> applyBodyCensors(Map<String, Object> dictionary) {
-        if (dictionary == null || dictionary.size() == 0) {
-            // short circuit if dictionary is null or empty
-            return dictionary;
+    /**
+     * Add a rule to censor specified body elements.
+     *
+     * @param elementKeys   Keys of body elements to censor.
+     * @param caseSensitive Whether to use case-sensitive censoring.
+     * @return This Censors factory.
+     */
+    public Censors hideBodyElementKeys(List<String> elementKeys, boolean caseSensitive) {
+        for (String elementKey : elementKeys) {
+            bodyElementsToCensor.add(new CensorElement(elementKey, caseSensitive));
         }
-
-        Map<String, Object> censoredBodyDictionary = new HashMap<>();
-
-        for (Map.Entry<String, Object> entry : dictionary.entrySet()) {
-            String key = entry.getKey();
-            Object value = entry.getValue();
-            if (keyShouldBeCensored(key, this.bodyParamsToCensor)) {
-                if (value == null) {
-                    // don't need to worry about censoring something that's null
-                    // (don't replace null with the censor string)
-                    continue;
-                } else if (Utilities.isDictionary(value)) {
-                    // replace with empty dictionary
-                    censoredBodyDictionary.put(key, new HashMap<>());
-                } else if (Utilities.isList(value)) {
-                    // replace with empty array
-                    censoredBodyDictionary.put(key, new ArrayList<>());
-                } else {
-                    // replace with censor text
-                    censoredBodyDictionary.put(key, this.censorText);
-                }
-            } else {
-                if (Utilities.isDictionary(value)) {
-                    // recursively censor inner dictionaries
-                    try {
-                        // change the value if can be parsed as a dictionary
-                        value = applyBodyCensors((Map<String, Object>) value);
-                    } catch (ClassCastException e) {
-                        // otherwise, skip censoring
-                    }
-                } else if (Utilities.isList(value)) {
-                    // recursively censor list elements
-                    try {
-                        // change the value if can be parsed as a list
-                        value = applyBodyCensors((List<Object>) value);
-                    } catch (ClassCastException e) {
-                        // otherwise, skip censoring
-                    }
-                }
-
-                censoredBodyDictionary.put(key, value);
-            }
-        }
-
-        return censoredBodyDictionary;
+        return this;
     }
 
-    private String censorJsonBodyParameters(String body) {
-        Map<String, Object> bodyDictionary;
-        try {
-            bodyDictionary = Serialization.convertJsonToObject(body, Map.class);
-            Map<String, Object> censoredBodyDictionary = applyBodyCensors(bodyDictionary);
-            return censoredBodyDictionary == null ? body : Serialization.convertObjectToJson(censoredBodyDictionary);
-        } catch (Exception ignored) {
-            // body is not a JSON dictionary
-            try {
-                List<Object> bodyList = Serialization.convertJsonToObject(body, List.class);
-                List<Object> censoredBodyList = applyBodyCensors(bodyList);
-                return censoredBodyList == null ? body : Serialization.convertObjectToJson(censoredBodyList);
-            } catch (Exception notJsonData) {
-                throw new JsonParseException("Body is not a JSON dictionary or list");
-            }
-        }
+    /**
+     * Add a rule to censor specified body elements.
+     *
+     * @param elementKeys Keys of body elementKeys to censor.
+     * @return This Censors factory.
+     */
+    public Censors hideBodyElementKeys(List<String> elementKeys) {
+        return hideBodyElementKeys(elementKeys, false);
     }
 
-    private boolean keyShouldBeCensored(String foundKey, List<String> keysToCensor) {
-        // keysToCensor are already cased as needed
-        if (!this.caseSensitive) {
-            foundKey = foundKey.toLowerCase();
-        }
+    /**
+     * Add a rule to censor specified header keys.
+     * Note: This will censor the header keys in both the request and response.
+     *
+     * @param headers List of Headers to censor.
+     * @return This Censors factory.
+     */
+    public Censors hideHeaders(List<CensorElement> headers) {
+        headersToCensor.addAll(headers);
+        return this;
+    }
 
-        return keysToCensor.contains(foundKey);
+    /**
+     * Add a rule to censor specified header keys.
+     * Note: This will censor the header keys in both the request and response.
+     *
+     * @param headerKeys    Keys of headers to censor.
+     * @param caseSensitive Whether to use case-sensitive censoring.
+     * @return This Censors factory.
+     */
+    public Censors hideHeaderKeys(List<String> headerKeys, boolean caseSensitive) {
+        for (String headerKey : headerKeys) {
+            headersToCensor.add(new CensorElement(headerKey, caseSensitive));
+        }
+        return this;
+    }
+
+    /**
+     * Add a rule to censor specified header keys.
+     * Note: This will censor the header keys in both the request and response.
+     *
+     * @param headerKeys Keys of headers to censor.
+     * @return This Censors factory.
+     */
+    public Censors hideHeaderKeys(List<String> headerKeys) {
+        return hideHeaderKeys(headerKeys, false);
+    }
+
+    /**
+     * Add a rule to censor specified query parameters.
+     *
+     * @param elements List of QueryElements to censor.
+     * @return This Censors factory.
+     */
+    public Censors hideQueryParameters(List<CensorElement> elements) {
+        queryParamsToCensor.addAll(elements);
+        return this;
+    }
+
+    /**
+     * Add a rule to censor specified query parameters.
+     *
+     * @param parameterKeys Keys of query parameters to censor.
+     * @param caseSensitive Whether to use case-sensitive censoring.
+     * @return This Censors factory.
+     */
+    public Censors hideQueryParameterKeys(List<String> parameterKeys, boolean caseSensitive) {
+        for (String parameterKey : parameterKeys) {
+            queryParamsToCensor.add(new CensorElement(parameterKey, caseSensitive));
+        }
+        return this;
+    }
+
+    /**
+     * Add a rule to censor specified query parameters.
+     *
+     * @param parameterKeys Keys of query parameters to censor.
+     * @return This Censors factory.
+     */
+    public Censors hideQueryParameterKeys(List<String> parameterKeys) {
+        return hideQueryParameterKeys(parameterKeys, false);
+    }
+
+    /**
+     * Censor the appropriate body elements.
+     *
+     * @param body String representation of request body to apply censors to.
+     * @return Censored string representation of request body.
+     */
+    public String censorBodyParameters(String body) {
+        return censorBodyParameters(body, this.censorText, this.bodyElementsToCensor);
+    }
+
+    /**
+     * Censor the appropriate headers.
+     *
+     * @param headers Map of headers to apply censors to.
+     * @return Censored map of headers.
+     */
+    public Map<String, List<String>> censorHeaders(Map<String, List<String>> headers) {
+        return censorHeaders(headers, this.censorText, this.headersToCensor);
+    }
+
+    /**
+     * Censor the appropriate query parameters.
+     *
+     * @param url Full URL string to apply censors to.
+     * @return Censored URL string.
+     */
+    public String censorQueryParameters(String url) {
+        return censorQueryParameters(url, this.censorText, this.queryParamsToCensor);
     }
 }

--- a/src/main/java/com/easypost/easyvcr/Censors.java
+++ b/src/main/java/com/easypost/easyvcr/Censors.java
@@ -76,6 +76,14 @@ public final class Censors {
         return censors;
     }
 
+    /**
+     * Apply censors to a JSON list.
+     *
+     * @param list             JSON list to process.
+     * @param censorText       Text to use when censoring an element.
+     * @param elementsToCensor List of elements to find and censor.
+     * @return Censored JSON list.
+     */
     private static List<Object> applyJsonCensors(List<Object> list, String censorText,
                                                  List<CensorElement> elementsToCensor) {
         if (list == null || list.size() == 0) {
@@ -109,9 +117,16 @@ public final class Censors {
         }
 
         return censoredList;
-
     }
 
+    /**
+     * Apply censors to a JSON dictionary.
+     *
+     * @param dictionary       JSON dictionary to process.
+     * @param censorText       Text to use when censoring an element.
+     * @param elementsToCensor List of elements to find and censor.
+     * @return Censored JSON dicstionary.
+     */
     private static Map<String, Object> applyJsonCensors(Map<String, Object> dictionary, String censorText,
                                                         List<CensorElement> elementsToCensor) {
         if (dictionary == null || dictionary.size() == 0) {
@@ -191,6 +206,13 @@ public final class Censors {
         }
     }
 
+    /**
+     * Check if the current JSON element should be censored.
+     *
+     * @param foundKey         Key of the JSON element to evaluate.
+     * @param elementsToCensor List of censors to compare against.
+     * @return True if the value should be censored, false otherwise.
+     */
     private static boolean keyShouldBeCensored(String foundKey, List<CensorElement> elementsToCensor) {
         return elementsToCensor.stream().anyMatch(queryElement -> queryElement.matches(foundKey));
     }

--- a/src/main/java/com/easypost/easyvcr/Censors.java
+++ b/src/main/java/com/easypost/easyvcr/Censors.java
@@ -243,6 +243,9 @@ public final class Censors {
 
         List<String> headerKeys = new ArrayList<>(headersCopy.keySet());
         for (String headerKey : headerKeys) {
+            if (headerKey == null) {
+                continue;
+            }
             if (keyShouldBeCensored(headerKey, headersToCensor)) {
                 headersCopy.put(headerKey, Collections.singletonList(censorText));
             }

--- a/src/main/java/com/easypost/easyvcr/HttpClients.java
+++ b/src/main/java/com/easypost/easyvcr/HttpClients.java
@@ -11,7 +11,7 @@ import java.net.URISyntaxException;
 /**
  * HttpClient singleton for EasyVCR.
  */
-public final class HttpClients {
+public abstract class HttpClients {
 
     /**
      * Get a new client configured to use cassettes.

--- a/src/main/java/com/easypost/easyvcr/MatchRules.java
+++ b/src/main/java/com/easypost/easyvcr/MatchRules.java
@@ -60,26 +60,43 @@ public final class MatchRules {
     /**
      * Add a rule to compare the bodies of the requests.
      *
+     * @param ignoredElements List of body elements to ignore when comparing the requests.
      * @return This MatchRules factory.
      */
-    public MatchRules byBody() {
+    public MatchRules byBody(List<CensorElement> ignoredElements) {
         by((received, recorded) -> {
-            if (received.getBody() == null && recorded.getBody() == null) {
+            String receivedBody = received.getBody();
+            String recordedBody = recorded.getBody();
+
+            if (receivedBody == null && recordedBody == null) {
                 // both have null bodies, so they match
                 return true;
             }
 
-            if (received.getBody() == null || recorded.getBody() == null) {
+            if (receivedBody == null || recordedBody == null) {
                 // one has a null body, so they don't match
                 return false;
             }
 
+            // remove ignored elements from the body
+            receivedBody = Utilities.removeJsonElements(receivedBody, ignoredElements);
+            recordedBody = Utilities.removeJsonElements(recordedBody, ignoredElements);
+
             // convert body to base64string to assist comparison by removing special characters
-            String receivedBody = Tools.toBase64String(received.getBody());
-            String recordedBody = Tools.toBase64String(recorded.getBody());
+            receivedBody = Tools.toBase64String(receivedBody);
+            recordedBody = Tools.toBase64String(recordedBody);
             return receivedBody.equalsIgnoreCase(recordedBody);
         });
         return this;
+    }
+
+    /**
+     * Add a rule to compare the bodies of the requests.
+     *
+     * @return This MatchRules factory.
+     */
+    public MatchRules byBody() {
+        return byBody(null);
     }
 
     /**

--- a/src/main/java/com/easypost/easyvcr/Statics.java
+++ b/src/main/java/com/easypost/easyvcr/Statics.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public final class Statics {
+public abstract class Statics {
     public static final String VIA_RECORDING_HEADER_KEY = "X-Via-EasyVCR-Recording";
     /**
      * Default headers to censor (credential-related headers).

--- a/src/main/java/com/easypost/easyvcr/Utilities.java
+++ b/src/main/java/com/easypost/easyvcr/Utilities.java
@@ -48,4 +48,18 @@ public class Utilities {
     public static boolean isList(Object obj) {
         return obj instanceof List;
     }
+
+    /**
+     * Remove elements from a JSON string.
+     * @param json The JSON string to remove elements from.
+     * @param elements The elements to remove.
+     * @return The JSON string without the elements.
+     */
+    public static String removeJsonElements(String json, List<CensorElement> elements) {
+        if (json == null || elements == null) {
+            return json;
+        }
+
+        return Censors.censorJsonData(json, "FILTERED", elements);
+    }
 }

--- a/src/main/java/com/easypost/easyvcr/Utilities.java
+++ b/src/main/java/com/easypost/easyvcr/Utilities.java
@@ -5,7 +5,7 @@ import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Map;
 
-public class Utilities {
+public abstract class Utilities {
 
     /**
      * Check if the connection came from an EasyVCR recording.

--- a/src/main/java/com/easypost/easyvcr/interactionconverters/HttpUrlConnectionInteractionConverter.java
+++ b/src/main/java/com/easypost/easyvcr/interactionconverters/HttpUrlConnectionInteractionConverter.java
@@ -42,9 +42,9 @@ public final class HttpUrlConnectionInteractionConverter extends BaseInteraction
             String method = connection.getRequestMethod();
 
             // apply censors
-            uriString = censors.censorQueryParameters(uriString);
-            headers = censors.censorHeaders(headers);
-            body = censors.censorBodyParameters(body);
+            uriString = censors.applyQueryParameterCensors(uriString);
+            headers = censors.applyHeaderCensors(headers);
+            body = censors.applyBodyParameterCensors(body);
 
 
             // create the request
@@ -88,8 +88,8 @@ public final class HttpUrlConnectionInteractionConverter extends BaseInteraction
             }
 
             // apply censors
-            uriString = censors.censorQueryParameters(uriString);
-            headers = censors.censorHeaders(headers);
+            uriString = censors.applyQueryParameterCensors(uriString);
+            headers = censors.applyHeaderCensors(headers);
             // we don't censor the response body, only the request body
 
             // create the response
@@ -98,11 +98,11 @@ public final class HttpUrlConnectionInteractionConverter extends BaseInteraction
             response.setUri(new URI(uriString));
             response.setHeaders(headers);
             if (body != null) {
-                body = censors.censorBodyParameters(body);
+                body = censors.applyBodyParameterCensors(body);
                 response.setBody(body);
             }
             if (errors != null) {
-                errors = censors.censorBodyParameters(errors);
+                errors = censors.applyBodyParameterCensors(errors);
                 response.setErrors(errors);
             }
 

--- a/src/main/java/com/easypost/easyvcr/internalutilities/Files.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/Files.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Files {
+public abstract class Files {
     /**
      * Creates a file if it doesn't exist.
      *

--- a/src/main/java/com/easypost/easyvcr/internalutilities/Tools.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/Tools.java
@@ -26,7 +26,7 @@ import java.util.Map;
 /**
  * Internal tools for EasyVCR.
  */
-public class Tools {
+public abstract class Tools {
     /**
      * Get a File object from a path.
      *

--- a/src/main/java/com/easypost/easyvcr/internalutilities/Utils.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/Utils.java
@@ -9,7 +9,7 @@ import java.util.function.BiPredicate;
 
 import static java.lang.String.format;
 
-public final class Utils {
+public abstract class Utils {
     private static final boolean[] T_CHAR = new boolean[256];
     private static final boolean[] FIELD_V_CHAR = new boolean[256];
 

--- a/src/main/java/com/easypost/easyvcr/internalutilities/json/Serialization.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/json/Serialization.java
@@ -7,7 +7,7 @@ import com.google.gson.JsonElement;
 /**
  * JSON de/serialization utilities.
  */
-public final class Serialization {
+public abstract class Serialization {
     /**
      * Convert a JSON string to an object.
      *

--- a/src/main/java/com/easypost/easyvcr/internalutilities/json/Serialization.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/json/Serialization.java
@@ -41,7 +41,7 @@ public final class Serialization {
      * @return JSON string
      */
     public static String convertObjectToJson(Object object) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
         return gson.toJson(object);
     }
 }

--- a/src/test/java/FakeDataService.java
+++ b/src/test/java/FakeDataService.java
@@ -3,24 +3,32 @@ import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpURLConnectio
 import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpsURLConnection;
 import com.easypost.easyvcr.internalutilities.json.Serialization;
 
+import java.util.List;
+
 import static com.easypost.easyvcr.internalutilities.Tools.readFromInputStream;
 
 public class FakeDataService {
 
-    public final static String GET_POSTS_URL = "https://jsonplaceholder.typicode.com/posts";
+    public class ExchangeRates {
+        public String code;
+        public String currency;
+        public List<Rate> rates;
+        public String table;
+    }
+
+    public class Rate {
+        public String effectiveDate;
+        public float mid;
+        public String no;
+    }
+
+    public static final String URL = "https://api.nbp.pl/api/exchangerates/rates/a/gbp/last/10/?format=json";
 
     private interface FakeDataServiceBaseInterface {
 
-        Post[] getPosts() throws Exception;
+        ExchangeRates getExchangeRates() throws Exception;
 
-        Object getPostsRawResponse() throws Exception;
-    }
-
-    public static class Post {
-        public int userId;
-        public int id;
-        public String title;
-        public String body;
+        Object getExchangeRatesRawResponse() throws Exception;
     }
 
     public static class HttpUrlConnection extends FakeDataServiceBase implements FakeDataServiceBaseInterface {
@@ -44,16 +52,16 @@ public class FakeDataService {
         }
 
         @Override
-        public Post[] getPosts() throws Exception {
-            RecordableHttpURLConnection client = (RecordableHttpURLConnection) getPostsRawResponse();
+        public ExchangeRates getExchangeRates() throws Exception {
+            RecordableHttpURLConnection client = (RecordableHttpURLConnection) getExchangeRatesRawResponse();
             String json = readFromInputStream(client.getInputStream());
 
-            return Serialization.convertJsonToObject(json, Post[].class);
+            return Serialization.convertJsonToObject(json, ExchangeRates.class);
         }
 
         @Override
-        public Object getPostsRawResponse() throws Exception {
-            RecordableHttpURLConnection client = getClient(GET_POSTS_URL);
+        public Object getExchangeRatesRawResponse() throws Exception {
+            RecordableHttpURLConnection client = getClient(URL);
             client.connect();
             return client;
         }
@@ -80,16 +88,16 @@ public class FakeDataService {
         }
 
         @Override
-        public Post[] getPosts() throws Exception {
-            RecordableHttpsURLConnection client = (RecordableHttpsURLConnection) getPostsRawResponse();
+        public ExchangeRates getExchangeRates() throws Exception {
+            RecordableHttpsURLConnection client = (RecordableHttpsURLConnection) getExchangeRatesRawResponse();
             String json = readFromInputStream(client.getInputStream());
 
-            return Serialization.convertJsonToObject(json, Post[].class);
+            return Serialization.convertJsonToObject(json, ExchangeRates.class);
         }
 
         @Override
-        public Object getPostsRawResponse() throws Exception {
-            RecordableHttpsURLConnection client = getClient(GET_POSTS_URL);
+        public Object getExchangeRatesRawResponse() throws Exception {
+            RecordableHttpsURLConnection client = getClient(URL);
             client.connect();
             return client;
         }

--- a/src/test/java/HttpUrlConnectionTest.java
+++ b/src/test/java/HttpUrlConnectionTest.java
@@ -59,7 +59,7 @@ public class HttpUrlConnectionTest {
 
         List<String> bodyCensors = new ArrayList<>();
         bodyCensors.add("Date");
-        advancedSettings.censors = new Censors("*****").hideBodyParameters(bodyCensors);
+        advancedSettings.censors = new Censors("*****").hideBodyElementKeys(bodyCensors);
 
         advancedSettings.matchRules = new MatchRules().byMethod().byBody().byFullUrl();
         RecordableHttpsURLConnection connection =
@@ -171,7 +171,7 @@ public class HttpUrlConnectionTest {
         String censorString = "censored-by-test";
         List<String> headers = new ArrayList<>();
         headers.add("Date");
-        Censors censors = new Censors(censorString).hideHeaders(headers);
+        Censors censors = new Censors(censorString).hideHeaderKeys(headers);
 
         AdvancedSettings advancedSettings = new AdvancedSettings();
         advancedSettings.censors = censors;

--- a/src/test/java/HttpUrlConnectionTest.java
+++ b/src/test/java/HttpUrlConnectionTest.java
@@ -1,5 +1,6 @@
 import com.easypost.easyvcr.AdvancedSettings;
 import com.easypost.easyvcr.Cassette;
+import com.easypost.easyvcr.CensorElement;
 import com.easypost.easyvcr.Censors;
 import com.easypost.easyvcr.HttpClientType;
 import com.easypost.easyvcr.HttpClients;
@@ -12,6 +13,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -22,12 +24,12 @@ import static com.easypost.easyvcr.internalutilities.Tools.readFromInputStream;
 
 public class HttpUrlConnectionTest {
 
-    private static FakeDataService.Post[] GetFakePostsRequest(Cassette cassette, Mode mode) throws Exception {
+    private static FakeDataService.ExchangeRates GetExchangeRatesRequest(Cassette cassette, Mode mode) throws Exception {
         RecordableHttpsURLConnection connection = TestUtils.getSimpleHttpsURLConnection(cassette.name, mode, null);
 
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
 
-        return fakeDataService.getPosts();
+        return fakeDataService.getExchangeRates();
     }
 
     @Test
@@ -102,7 +104,7 @@ public class HttpUrlConnectionTest {
         Cassette cassette = TestUtils.getCassette("test_erase");
 
         // record something to the cassette
-        FakeDataService.Post[] posts = GetFakePostsRequest(cassette, Mode.Record);
+        FakeDataService.ExchangeRates exchangeRates = GetExchangeRatesRequest(cassette, Mode.Record);
         Assert.assertTrue(cassette.numInteractions() > 0);
 
         // erase the cassette
@@ -115,10 +117,9 @@ public class HttpUrlConnectionTest {
         Cassette cassette = TestUtils.getCassette("test_erase_and_record");
         cassette.erase(); // Erase cassette before recording
 
-        FakeDataService.Post[] posts = GetFakePostsRequest(cassette, Mode.Record);
+        FakeDataService.ExchangeRates exchangeRates = GetExchangeRatesRequest(cassette, Mode.Record);
 
-        Assert.assertNotNull(posts);
-        Assert.assertEquals(posts.length, 100);
+        Assert.assertNotNull(exchangeRates);
         Assert.assertTrue(cassette.numInteractions() > 0); // Make sure cassette is not empty
     }
 
@@ -128,7 +129,7 @@ public class HttpUrlConnectionTest {
         cassette.erase(); // Erase cassette before recording
 
         // cassette is empty, so replaying should throw an exception
-        Assert.assertThrows(Exception.class, () -> GetFakePostsRequest(cassette, Mode.Replay));
+        Assert.assertThrows(Exception.class, () -> GetExchangeRatesRequest(cassette, Mode.Replay));
     }
 
     @Test
@@ -137,12 +138,12 @@ public class HttpUrlConnectionTest {
         cassette.erase(); // Erase cassette before recording
 
         // in replay mode, if cassette is empty, should throw an exception
-        Assert.assertThrows(Exception.class, () -> GetFakePostsRequest(cassette, Mode.Replay));
+        Assert.assertThrows(Exception.class, () -> GetExchangeRatesRequest(cassette, Mode.Replay));
         Assert.assertEquals(cassette.numInteractions(), 0); // Make sure cassette is still empty
 
         // in auto mode, if cassette is empty, should make and record a real request
-        FakeDataService.Post[] posts = GetFakePostsRequest(cassette, Mode.Auto);
-        Assert.assertNotNull(posts);
+        FakeDataService.ExchangeRates exchangeRates = GetExchangeRatesRequest(cassette, Mode.Auto);
+        Assert.assertNotNull(exchangeRates);
         Assert.assertTrue(cassette.numInteractions() > 0); // Make sure cassette is no longer empty
     }
 
@@ -153,12 +154,12 @@ public class HttpUrlConnectionTest {
 
         RecordableHttpsURLConnection connection =
                 (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                        FakeDataService.GET_POSTS_URL, cassette, Mode.Record);
+                        FakeDataService.URL, cassette, Mode.Record);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
 
         // Most elements of a VCR request are black-boxed, so we can't test them here.
         // Instead, we can get the recreated HttpResponseMessage and check the details.
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getPostsRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
         Assert.assertNotNull(response);
     }
 
@@ -179,15 +180,15 @@ public class HttpUrlConnectionTest {
         // record cassette with advanced settings first
         RecordableHttpsURLConnection connection =
                 (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                        FakeDataService.GET_POSTS_URL, cassette, Mode.Record, advancedSettings);
+                        FakeDataService.URL, cassette, Mode.Record, advancedSettings);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        Object ignore = fakeDataService.getPostsRawResponse();
+        Object ignore = fakeDataService.getExchangeRatesRawResponse();
 
         // now replay cassette
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                FakeDataService.GET_POSTS_URL, cassette, Mode.Replay, advancedSettings);
+                FakeDataService.URL, cassette, Mode.Replay, advancedSettings);
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getPostsRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
 
         // check that the replayed response contains the censored header
         Assert.assertNotNull(response);
@@ -205,17 +206,17 @@ public class HttpUrlConnectionTest {
         // record cassette with advanced settings first
         RecordableHttpsURLConnection connection =
                 (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                        FakeDataService.GET_POSTS_URL, cassette, Mode.Record);
+                        FakeDataService.URL, cassette, Mode.Record);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        Object ignore = fakeDataService.getPostsRawResponse();
+        Object ignore = fakeDataService.getExchangeRatesRawResponse();
 
         // replay cassette with default match rules, should find a match
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                FakeDataService.GET_POSTS_URL, cassette, Mode.Replay);
+                FakeDataService.URL, cassette, Mode.Replay);
         connection.setRequestProperty("X-Custom-Header",
                 "custom-value"); // add custom header to request, shouldn't matter when matching by default rules
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getPostsRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
         Assert.assertNotNull(response);
 
         // replay cassette with custom match rules, should not find a match because request is different (throw exception)
@@ -224,12 +225,12 @@ public class HttpUrlConnectionTest {
         advancedSettings.matchRules = matchRules;
 
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                FakeDataService.GET_POSTS_URL, cassette, Mode.Replay, advancedSettings);
+                FakeDataService.URL, cassette, Mode.Replay, advancedSettings);
         connection.setRequestProperty("X-Custom-Header",
                 "custom-value"); // add custom header to request, causing a match failure when matching by everything
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
         FakeDataService.HttpsUrlConnection finalFakeDataService = fakeDataService;
-        Assert.assertThrows(Exception.class, () -> finalFakeDataService.getPosts());
+        Assert.assertThrows(Exception.class, () -> finalFakeDataService.getExchangeRates());
     }
 
     @Test
@@ -240,21 +241,21 @@ public class HttpUrlConnectionTest {
         // record cassette first
         RecordableHttpsURLConnection connection =
                 (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                        FakeDataService.GET_POSTS_URL, cassette, Mode.Record);
+                        FakeDataService.URL, cassette, Mode.Record);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        Object ignore = fakeDataService.getPosts();
+        Object ignore = fakeDataService.getExchangeRates();
 
         // baseline - how much time does it take to replay the cassette?
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                FakeDataService.GET_POSTS_URL, cassette, Mode.Replay);
+                FakeDataService.URL, cassette, Mode.Replay);
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
 
         Instant start = Instant.now();
-        FakeDataService.Post[] posts = fakeDataService.getPosts();
+        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
         Instant end = Instant.now();
 
         // confirm the normal replay worked, note time
-        Assert.assertNotNull(posts);
+        Assert.assertNotNull(exchangeRates);
         int normalReplayTime = (int) Duration.between(start, end).toMillis();
 
         // set up advanced settings
@@ -262,16 +263,92 @@ public class HttpUrlConnectionTest {
         AdvancedSettings advancedSettings = new AdvancedSettings();
         advancedSettings.manualDelay = delay;
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
-                FakeDataService.GET_POSTS_URL, cassette, Mode.Replay, advancedSettings);
+                FakeDataService.URL, cassette, Mode.Replay, advancedSettings);
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
 
         // time replay request
         start = Instant.now();
-        posts = fakeDataService.getPosts();
+        exchangeRates = fakeDataService.getExchangeRates();
         end = Instant.now();
 
         // check that the delay was respected
-        Assert.assertNotNull(posts);
+        Assert.assertNotNull(exchangeRates);
         Assert.assertTrue((int) Duration.between(start, end).toMillis() >= delay);
+    }
+
+    @Test
+    public void testIgnoreElements() throws URISyntaxException, IOException {
+        Cassette cassette = TestUtils.getCassette("test_ignore_elements");
+        cassette.erase(); // Erase cassette before recording
+
+        String bodyData1 = "{'name': 'Upendra', 'job': 'Programmer'}";
+        String bodyData2 = "{'name': 'NewName', 'job': 'Programmer'}";
+
+        // record baseline request first
+        RecordableHttpsURLConnection connection = HttpClients.newHttpsURLConnection(FakeDataService.URL, cassette, Mode.Record);
+        connection.setDoOutput(true);
+        connection.setRequestMethod("POST");
+        // use bodyData1 to make request
+        OutputStream output = null;
+        try {
+            output = connection.getOutputStream();
+            output.write(bodyData1.getBytes(StandardCharsets.UTF_8));
+        } finally {
+            if (output != null) {
+                output.close();
+            }
+        }
+        connection.connect();
+
+        // try to replay with slightly different data
+        AdvancedSettings advancedSettings = new AdvancedSettings();
+        // matching strictly by body
+        advancedSettings.matchRules = new MatchRules().byMethod().byFullUrl().byBody();
+        connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
+                FakeDataService.URL, cassette, Mode.Replay, advancedSettings);
+        connection.setDoOutput(true);
+        connection.setRequestMethod("POST");
+        // use bodyData2 to make request
+        output = null;
+        try {
+            output = connection.getOutputStream();
+            output.write(bodyData2.getBytes(StandardCharsets.UTF_8));
+        } finally {
+            if (output != null) {
+                output.close();
+            }
+        }
+        connection.connect();
+
+        // should fail since we're strictly in replay mode and there's no exact match
+        int statusCode = connection.getResponseCode();
+        Assert.assertEquals(0, statusCode);
+
+        // try to replay with slightly different data, but ignoring the differences
+        advancedSettings = new AdvancedSettings();
+        // ignore the element that is different
+        List<CensorElement> ignoredElements = new ArrayList<CensorElement>() {{
+            add(new CensorElement("name", false));
+        }};
+        advancedSettings.matchRules = new MatchRules().byMethod().byFullUrl().byBody(ignoredElements);
+        connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
+                FakeDataService.URL, cassette, Mode.Replay, advancedSettings);
+        connection.setDoOutput(true);
+        connection.setRequestMethod("POST");
+        // use bodyData2 to make request
+        output = null;
+        try {
+            output = connection.getOutputStream();
+            output.write(bodyData2.getBytes(StandardCharsets.UTF_8));
+        } finally {
+            if (output != null) {
+                output.close();
+            }
+        }
+        connection.connect();
+
+        // should not fail since we're ignoring the body elements that differ
+        statusCode = connection.getResponseCode();
+        Assert.assertNotEquals(0, statusCode);
     }
 }

--- a/src/test/java/TestUtils.java
+++ b/src/test/java/TestUtils.java
@@ -25,7 +25,7 @@ public class TestUtils {
 
     public static RecordableHttpURLConnection getSimpleHttpURLConnection(String cassetteName, Mode mode, AdvancedSettings advancedSettings)
             throws IOException {
-        return getSimpleHttpURLConnection(FakeDataService.GET_POSTS_URL, cassetteName, mode, advancedSettings);
+        return getSimpleHttpURLConnection(FakeDataService.URL, cassetteName, mode, advancedSettings);
     }
 
     public static RecordableHttpsURLConnection getSimpleHttpsURLConnection(String url, String cassetteName, Mode mode, AdvancedSettings advancedSettings)
@@ -36,7 +36,7 @@ public class TestUtils {
 
     public static RecordableHttpsURLConnection getSimpleHttpsURLConnection(String cassetteName, Mode mode, AdvancedSettings advancedSettings)
             throws IOException {
-        return getSimpleHttpsURLConnection(FakeDataService.GET_POSTS_URL, cassetteName, mode, advancedSettings);
+        return getSimpleHttpsURLConnection(FakeDataService.URL, cassetteName, mode, advancedSettings);
     }
 
     public static VCR getSimpleVCR(Mode mode) {

--- a/src/test/java/VCRTest.java
+++ b/src/test/java/VCRTest.java
@@ -77,8 +77,8 @@ public class VCRTest {
 
         // record a request to a cassette
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(vcr);
-        FakeDataService.Post[] posts = fakeDataService.getPosts();
-        Assert.assertNotNull(posts);
+        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
+        Assert.assertNotNull(exchangeRates);
         Assert.assertTrue(cassette.numInteractions() > 0);
 
         // erase the cassette
@@ -108,9 +108,8 @@ public class VCRTest {
         vcr.insert(cassette);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(vcr);
 
-        FakeDataService.Post[] posts = fakeDataService.getPosts();
-        Assert.assertNotNull(posts);
-        Assert.assertEquals(100, posts.length);
+        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
+        Assert.assertNotNull(exchangeRates);
     }
 
     @Test
@@ -120,9 +119,8 @@ public class VCRTest {
         vcr.insert(cassette);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(vcr);
 
-        FakeDataService.Post[] posts = fakeDataService.getPosts();
-        Assert.assertNotNull(posts);
-        Assert.assertEquals(100, posts.length);
+        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
+        Assert.assertNotNull(exchangeRates);
         Assert.assertTrue(cassette.numInteractions() > 0);
     }
 
@@ -134,14 +132,14 @@ public class VCRTest {
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(vcr);
 
         // record first
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getPostsRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
         Assert.assertTrue(cassette.numInteractions() > 0); // make sure we recorded something
         // check that the response did not come from a recorded cassette
         Assert.assertFalse(Utilities.responseCameFromRecording(response));
 
         // now replay
         vcr.replay();
-        response = (RecordableHttpsURLConnection) fakeDataService.getPostsRawResponse();
+        response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
         Assert.assertNotNull(response);
         // check that the response came from a recorded cassette
         Assert.assertTrue(Utilities.responseCameFromRecording(response));
@@ -149,7 +147,7 @@ public class VCRTest {
         // double check by erasing the cassette and trying to replay
         vcr.erase();
         // should throw an exception because there's no matching interaction now
-        Assert.assertThrows(Exception.class, fakeDataService::getPosts);
+        Assert.assertThrows(Exception.class, fakeDataService::getExchangeRates);
     }
 
     @Test
@@ -174,7 +172,7 @@ public class VCRTest {
         AdvancedSettings advancedSettings = new AdvancedSettings();
         List<String> censoredHeaders = new ArrayList<>();
         censoredHeaders.add("Date");
-        advancedSettings.censors = new Censors(censorString).hideHeaders(censoredHeaders);
+        advancedSettings.censors = new Censors(censorString).hideHeaderKeys(censoredHeaders);
         advancedSettings.matchRules = new MatchRules().byMethod().byFullUrl().byBody();
 
         VCR vcr = new VCR(advancedSettings);
@@ -189,18 +187,18 @@ public class VCRTest {
 
         // record first
         vcr.record();
-        RecordableURL client = vcr.getHttpUrlConnection(FakeDataService.GET_POSTS_URL);
+        RecordableURL client = vcr.getHttpUrlConnection(FakeDataService.URL);
         FakeDataService.HttpsUrlConnection fakeDataService =
                 new FakeDataService.HttpsUrlConnection(client.openConnectionSecure());
-        FakeDataService.Post[] posts = fakeDataService.getPosts();
+        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
 
         // now replay and confirm that the censor is applied
         vcr.replay();
         // changing the VCR settings won't affect a client after it's been grabbed from the VCR
         // so, we need to re-grab the VCR client and re-create the FakeDataService
-        client = vcr.getHttpUrlConnection(FakeDataService.GET_POSTS_URL);
+        client = vcr.getHttpUrlConnection(FakeDataService.URL);
         fakeDataService = new FakeDataService.HttpsUrlConnection(client.openConnectionSecure());
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getPostsRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
 
         // check that the censor is applied
         Assert.assertNotNull(response);

--- a/src/test/java/VCRTest.java
+++ b/src/test/java/VCRTest.java
@@ -172,7 +172,7 @@ public class VCRTest {
         AdvancedSettings advancedSettings = new AdvancedSettings();
         List<String> censoredHeaders = new ArrayList<>();
         censoredHeaders.add("Date");
-        advancedSettings.censors = new Censors(censorString).hideHeaderKeys(censoredHeaders);
+        advancedSettings.censors = new Censors(censorString).censorHeadersByKeys(censoredHeaders);
         advancedSettings.matchRules = new MatchRules().byMethod().byFullUrl().byBody();
 
         VCR vcr = new VCR(advancedSettings);

--- a/style_suppressions.xml
+++ b/style_suppressions.xml
@@ -5,12 +5,27 @@
         "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
-    <!-- TODO: Include Test files -->
     <!-- Don't do any CheckStyle checks on any Test files. -->
     <suppress checks="[a-zA-Z0-9]*"
               files="src[\\/]test[\\/].*"/>
     <suppress checks="[a-zA-Z0-9]*"
               files=".*Test.java"/>
+    <!-- Disabling picky CheckStyle checks that don't understand how this package is structured. -->
+    <suppress checks="VisibilityModifier"
+              files="src[\\/]main[\\/].*"/>
+    <suppress checks="JavadocPackage"
+              files="src[\\/]main[\\/].*"/>
+    <suppress checks="ParameterNumber"
+              files="src[\\/]main[\\/].*"/>
+    <!--- Need to suppress below checks due to overridden HttpUrlConnection class code -->
+    <suppress checks="MagicNumber"
+              files="src[\\/]main[\\/].*"/>
+    <suppress checks="ParameterName"
+              files="src[\\/]main[\\/].*"/>
+    <suppress checks="MethodLength"
+              files="src[\\/]main[\\/].*"/>
+    <suppress checks="UnusedImports"
+              files="src[\\/]main[\\/].*"/>
     <!-- Don't do any CheckStyle checks on any non-Java files. -->
     <suppress files=".+\.(?:txt|xml|csv|sh|thrift|html|sql|eot|ttf|woff|css|png)$"
               checks=".*"/>


### PR DESCRIPTION
- Reuse censoring code to effectively ignore (normalize) specific elements in the bodies when matching by request body.
- Made a number of censoring methods static for normalization purposes, with instance-based overloads for normal censoring process.
- Side-effect improvement: Censored header/query/body elements can now be case-sensitive on a per-element basis.
- Changed data service used for unit tests to match C# version.