### PR TITLE
Expiration controls and custom logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Next Release
+- New feature: Set expiration time for interactions (how long since it was recorded should an interaction be considered valid)
+  - Can determine what to do if a matching interaction is considered invalid:
+    - Warn the user, but proceed with the interaction
+    - Throw an exception
+    - Automatically re-record (cannot be used in `Replay` mode)
+- New feature: Pass in a custom Logger instance to EasyVCR to funnel log messages into your own logging setup (fallback: logs to console)
+
 ## v0.3.0 (2022-06-13)
 
 - Improvements to censoring

--- a/README.md
+++ b/README.md
@@ -159,6 +159,40 @@ public class Example {
 }
 ```
 
+### Expiration
+
+Set expiration dates for recorded requests, and decide what to do with expired recordings.
+
+**Default**: *No expiration*
+
+```java
+import com.easypost.easyvcr;
+import com.easypost.easyvcr.AdvancedSettings;
+import com.easypost.easyvcr.Cassette;
+import com.easypost.easyvcr.ExpirationActions;
+import com.easypost.easyvcr.Mode;
+import com.easypost.easyvcr.TimeFrame;
+import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpsURLConnection;
+import com.easypost.easyvcr.clients.httpurlconnection.RecordableURL;
+
+public class Example {
+    public static void main(String[] args) {
+        Cassette cassette = new Cassette("path/to/cassettes", "my_cassette");
+
+        AdvancedSettings advancedSettings = new AdvancedSettings();
+        advancedSettings.timeFrame = new TimeFrame(30, 0, 0, 0); // Any matching request is considered expired if it was recorded more than 30 days ago
+        // or
+        advancedSettings.timeFrame = TimeFrame.months12(); // Any matching request is considered expired if it was recorded more than a year ago
+        advancedSettings.whenExpired = ExpirationActions.Throw_Exception; // Throw exception if the recording is expired
+
+        RecordableURL recordableURL =
+                new RecordableURL("https://www.example.com", cassette, Mode.Replay, advancedSettings);
+
+        RecordableHttpsURLConnection connection = recordableURL.openConnectionSecure();
+    }
+}
+```
+
 ### Matching
 
 Customize how a recorded request is determined to be a match to the current request.
@@ -183,6 +217,35 @@ public class Example {
         // or
         advancedSettings.matchRules = MatchRules.strict(); // use the built-in strict matching mode (matches by method, full URL and request body; useful for POST/PATCH/PUT requests)
         
+        RecordableURL recordableURL =
+                new RecordableURL("https://www.example.com", cassette, Mode.Replay, advancedSettings);
+
+        RecordableHttpsURLConnection connection = recordableURL.openConnectionSecure();
+    }
+}
+```
+
+### Logging
+
+Have EasyVCR integrate with your custom logger to log warnings and errors.
+
+**Default**: *Logs to console*
+
+```java
+import com.easypost.easyvcr;
+import com.easypost.easyvcr.AdvancedSettings;
+import com.easypost.easyvcr.Cassette;
+import com.easypost.easyvcr.MatchRules;
+import com.easypost.easyvcr.Mode;
+import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpsURLConnection;
+import com.easypost.easyvcr.clients.httpurlconnection.RecordableURL;
+
+public class Example {
+    public static void main(String[] args) {
+        Cassette cassette = new Cassette("path/to/cassettes", "my_cassette");
+
+        AdvancedSettings advancedSettings = new AdvancedSettings();
+        advancedSettings.logger = new MyCustomLogger(); // Have EasyVCR use your custom logger when making log entries
         RecordableURL recordableURL =
                 new RecordableURL("https://www.example.com", cassette, Mode.Replay, advancedSettings);
 

--- a/README.md
+++ b/README.md
@@ -180,10 +180,12 @@ public class Example {
         Cassette cassette = new Cassette("path/to/cassettes", "my_cassette");
 
         AdvancedSettings advancedSettings = new AdvancedSettings();
-        advancedSettings.timeFrame = new TimeFrame(30, 0, 0, 0); // Any matching request is considered expired if it was recorded more than 30 days ago
+        advancedSettings.timeFrame = new TimeFrame(30, 0, 0,
+                0); // Any matching request is considered expired if it was recorded more than 30 days ago
         // or
-        advancedSettings.timeFrame = TimeFrame.months12(); // Any matching request is considered expired if it was recorded more than a year ago
-        advancedSettings.whenExpired = ExpirationActions.Throw_Exception; // Throw exception if the recording is expired
+        advancedSettings.timeFrame =
+                TimeFrame.months12(); // Any matching request is considered expired if it was recorded more than a year ago
+        advancedSettings.whenExpired = ExpirationActions.ThrowException; // Throw exception if the recording is expired
 
         RecordableURL recordableURL =
                 new RecordableURL("https://www.example.com", cassette, Mode.Replay, advancedSettings);

--- a/src/main/java/com/easypost/easyvcr/AdvancedSettings.java
+++ b/src/main/java/com/easypost/easyvcr/AdvancedSettings.java
@@ -1,5 +1,7 @@
 package com.easypost.easyvcr;
 
+import java.util.logging.Logger;
+
 public final class AdvancedSettings {
     public MatchRules matchRules = MatchRules.regular();
 
@@ -8,4 +10,10 @@ public final class AdvancedSettings {
     public boolean simulateDelay = false;
 
     public int manualDelay = 0;
+
+    public TimeFrame timeFrame = TimeFrame.forever();
+
+    public ExpirationActions whenExpired = ExpirationActions.Warn;
+
+    public Logger logger = null;
 }

--- a/src/main/java/com/easypost/easyvcr/ExpirationActions.java
+++ b/src/main/java/com/easypost/easyvcr/ExpirationActions.java
@@ -11,9 +11,9 @@ public enum ExpirationActions {
     /**
      * Throw an exception that the recorded interaction is expired.
      */
-    Throw_Exception,
+    ThrowException,
     /**
      * Automatically re-record the recorded interaction. This cannot be used with {@link Mode#Replay}.
      */
-    Record_Again,
+    RecordAgain,
 }

--- a/src/main/java/com/easypost/easyvcr/ExpirationActions.java
+++ b/src/main/java/com/easypost/easyvcr/ExpirationActions.java
@@ -1,0 +1,19 @@
+package com.easypost.easyvcr;
+
+/**
+ * Enums representing different actions to take when a recording is expired.
+ */
+public enum ExpirationActions {
+    /**
+     * Warn that the recorded interaction is expired, but proceed as normal.
+     */
+    Warn,
+    /**
+     * Throw an exception that the recorded interaction is expired.
+     */
+    Throw_Exception,
+    /**
+     * Automatically re-record the recorded interaction. This cannot be used with {@link Mode#Replay}.
+     */
+    Record_Again,
+}

--- a/src/main/java/com/easypost/easyvcr/HttpClients.java
+++ b/src/main/java/com/easypost/easyvcr/HttpClients.java
@@ -26,7 +26,8 @@ public abstract class HttpClients {
      * @throws IOException        If there is an error creating the client.
      */
     public static Object newClient(HttpClientType type, String url, Cassette cassette, Mode mode,
-                                   AdvancedSettings advancedSettings) throws URISyntaxException, IOException {
+                                   AdvancedSettings advancedSettings)
+            throws URISyntaxException, IOException, RecordingExpirationException {
         switch (type) {
             case HttpUrlConnection:
                 return newHttpURLConnection(url, cassette, mode, advancedSettings);
@@ -49,7 +50,7 @@ public abstract class HttpClients {
      * @throws IOException        If there is an error creating the client.
      */
     public static Object newClient(HttpClientType type, String url, Cassette cassette, Mode mode)
-            throws URISyntaxException, IOException {
+            throws URISyntaxException, IOException, RecordingExpirationException {
         return newClient(type, url, cassette, mode, null);
     }
 
@@ -80,7 +81,7 @@ public abstract class HttpClients {
      */
     public static RecordableHttpURLConnection newHttpURLConnection(String url, Cassette cassette, Mode mode,
                                                                    AdvancedSettings advancedSettings)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         return newRecordableURL(url, cassette, mode, advancedSettings).openConnection();
     }
 
@@ -94,7 +95,7 @@ public abstract class HttpClients {
      * @throws IOException If there is an error creating the client.
      */
     public static RecordableHttpURLConnection newHttpURLConnection(String url, Cassette cassette, Mode mode)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         return newRecordableURL(url, cassette, mode, null).openConnection();
     }
 
@@ -110,7 +111,7 @@ public abstract class HttpClients {
      */
     public static RecordableHttpsURLConnection newHttpsURLConnection(String url, Cassette cassette, Mode mode,
                                                                      AdvancedSettings advancedSettings)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         return newRecordableURL(url, cassette, mode, advancedSettings).openConnectionSecure();
     }
 
@@ -124,7 +125,7 @@ public abstract class HttpClients {
      * @throws IOException If there is an error creating the client.
      */
     public static RecordableHttpsURLConnection newHttpsURLConnection(String url, Cassette cassette, Mode mode)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         return newRecordableURL(url, cassette, mode, null).openConnectionSecure();
     }
 }

--- a/src/main/java/com/easypost/easyvcr/RecordingExpirationException.java
+++ b/src/main/java/com/easypost/easyvcr/RecordingExpirationException.java
@@ -1,6 +1,6 @@
 package com.easypost.easyvcr;
 
-public final class RecordingExpirationException extends Exception{
+public final class RecordingExpirationException extends Exception {
     /**
      * Constructs a new RecordingExpirationException with the specified detail message.
      *

--- a/src/main/java/com/easypost/easyvcr/RecordingExpirationException.java
+++ b/src/main/java/com/easypost/easyvcr/RecordingExpirationException.java
@@ -1,0 +1,12 @@
+package com.easypost.easyvcr;
+
+public final class RecordingExpirationException extends Exception{
+    /**
+     * Constructs a new RecordingExpirationException with the specified detail message.
+     *
+     * @param message the error message.
+     */
+    public RecordingExpirationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/easypost/easyvcr/TimeFrame.java
+++ b/src/main/java/com/easypost/easyvcr/TimeFrame.java
@@ -33,7 +33,7 @@ public class TimeFrame {
      * Enums for common time frames.
      */
     private enum CommonTimeFrames {
-        FOREVER, NEVER
+        Forever, Never
     }
 
     /**
@@ -90,9 +90,9 @@ public class TimeFrame {
      */
     private Instant timePlusFrame(Instant fromTime) {
         switch (commonTimeFrame) {
-            case FOREVER:
+            case Forever:
                 return Instant.MAX;  // will always been in the future
-            case NEVER:
+            case Never:
                 return Instant.MIN; // will always been in the past
             default:
                 return fromTime.plus(days, ChronoUnit.DAYS).plus(hours, ChronoUnit.HOURS)
@@ -106,7 +106,7 @@ public class TimeFrame {
      * @return TimeFrame that represents "forever".
      */
     public static TimeFrame forever() {
-        return new TimeFrame(CommonTimeFrames.FOREVER);
+        return new TimeFrame(CommonTimeFrames.Forever);
     }
 
     /**
@@ -115,7 +115,7 @@ public class TimeFrame {
      * @return TimeFrame that represents "never".
      */
     public static TimeFrame never() {
-        return new TimeFrame(CommonTimeFrames.NEVER);
+        return new TimeFrame(CommonTimeFrames.Never);
     }
 
     /**

--- a/src/main/java/com/easypost/easyvcr/TimeFrame.java
+++ b/src/main/java/com/easypost/easyvcr/TimeFrame.java
@@ -1,0 +1,165 @@
+package com.easypost.easyvcr;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * TimeFrame used to store an extent of time.
+ */
+public class TimeFrame {
+    /**
+     * Number of days for this time frame.
+     */
+    private int days = 0;
+    /**
+     * Number of hours for this time frame.
+     */
+    private int hours = 0;
+    /**
+     * Number of minutes for this time frame.
+     */
+    private int minutes = 0;
+    /**
+     * Number of seconds for this time frame.
+     */
+    private int seconds = 0;
+
+    /**
+     * If this time frame is a common time frame.
+     */
+    private CommonTimeFrames commonTimeFrame = null;
+
+    /**
+     * Enums for common time frames.
+     */
+    private enum CommonTimeFrames {
+        FOREVER, NEVER
+    }
+
+    /**
+     * Constructor for TimeFrame.
+     *
+     * @param days    The number of days in the time frame.
+     * @param hours   The number of hours in the time frame.
+     * @param minutes The number of minutes in the time frame.
+     * @param seconds The number of seconds in the time frame.
+     */
+    public TimeFrame(int days, int hours, int minutes, int seconds) {
+        this.days = days;
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+    }
+
+    /**
+     * Constructor for TimeFrame.
+     *
+     * @param commonTimeFrame The common time frame to use.
+     */
+    private TimeFrame(CommonTimeFrames commonTimeFrame) {
+        this.commonTimeFrame = commonTimeFrame;
+    }
+
+    /**
+     * Check if this time frame has lapsed from the given time.
+     *
+     * @param fromTime Time to add time frame to.
+     * @return Whether this time frame has lapsed.
+     */
+    public boolean hasLapsed(Instant fromTime) {
+        Instant startTimePlusFrame = timePlusFrame(fromTime);
+        return startTimePlusFrame.isBefore(Instant.now());
+    }
+
+    /**
+     * Check if this time frame has lapsed from the given time.
+     *
+     * @param fromTimeEpochTimestamp Epoch timestamp of the time to add time frame to.
+     * @return Whether this time frame has lapsed.
+     */
+    public boolean hasLapsed(long fromTimeEpochTimestamp) {
+        Instant fromTime = Instant.ofEpochSecond(fromTimeEpochTimestamp);
+        return hasLapsed(fromTime);
+    }
+
+    /**
+     * Get the provided time plus the time frame.
+     *
+     * @param fromTime Starting time.
+     * @return Starting time plus this time frame.
+     */
+    private Instant timePlusFrame(Instant fromTime) {
+        switch (commonTimeFrame) {
+            case FOREVER:
+                return Instant.MAX;  // will always been in the future
+            case NEVER:
+                return Instant.MIN; // will always been in the past
+            default:
+                return fromTime.plus(days, ChronoUnit.DAYS).plus(hours, ChronoUnit.HOURS)
+                        .plus(minutes, ChronoUnit.MINUTES).plus(seconds, ChronoUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Get a TimeFrame that represents "forever".
+     *
+     * @return TimeFrame that represents "forever".
+     */
+    public static TimeFrame forever() {
+        return new TimeFrame(CommonTimeFrames.FOREVER);
+    }
+
+    /**
+     * Get a TimeFrame that represents "never".
+     *
+     * @return TimeFrame that represents "never".
+     */
+    public static TimeFrame never() {
+        return new TimeFrame(CommonTimeFrames.NEVER);
+    }
+
+    /**
+     * Get a TimeFrame that represents 1 month.
+     *
+     * @return TimeFrame that represents 1 month.
+     */
+    public static TimeFrame months1() {
+        return new TimeFrame(30, 0, 0, 0);
+    }
+
+    /**
+     * Get a TimeFrame that represents 2 months.
+     *
+     * @return TimeFrame that represents 2 months.
+     */
+    public static TimeFrame months2() {
+        return new TimeFrame(61, 0, 0, 0);
+    }
+
+    /**
+     * Get a TimeFrame that represents 3 months.
+     *
+     * @return TimeFrame that represents 3 months.
+     */
+    public static TimeFrame months3() {
+        return new TimeFrame(91, 0, 0, 0);
+    }
+
+    /**
+     * Get a TimeFrame that represents 6 months.
+     *
+     * @return TimeFrame that represents 6 months.
+     */
+    public static TimeFrame months6() {
+        return new TimeFrame(182, 0, 0, 0);
+    }
+
+    /**
+     * Get a TimeFrame that represents 12 months.
+     *
+     * @return TimeFrame that represents 12 months.
+     */
+    public static TimeFrame months12() {
+        return new TimeFrame(365, 0, 0, 0);
+    }
+}

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
@@ -252,9 +252,9 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
                         case Warn:
                             this.logger.warning("Matching interaction is expired.");
                             break;
-                        case Throw_Exception:
+                        case ThrowException:
                             throw new RecordingExpirationException("Matching interaction is expired.");
-                        case Record_Again:
+                        case RecordAgain:
                             // we should never get here, but just in case.
                             throw new RecordingExpirationException(
                                     "Cannot use the Record_Again expiration action in combination with Replay mode.");
@@ -267,9 +267,9 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
                         case Warn:
                             this.logger.warning("Matching interaction is expired.");
                             break;
-                        case Throw_Exception:
+                        case ThrowException:
                             throw new RecordingExpirationException("Matching interaction is expired.");
-                        case Record_Again:
+                        case RecordAgain:
                             // will trigger a re-recording of the interaction
                             return false;
                         default:

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpRetryException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.SocketPermission;
@@ -358,7 +359,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache(); // can't set anything after connecting, so might as well build the cache now
             // will establish connection as a result of caching, so need to disconnect afterwards
             this.connection.disconnect();
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -394,7 +395,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache();
             return getStringElementFromCache(
                     (interaction) -> interaction.getResponse().getHeaders().keySet().toArray()[n].toString(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -526,7 +527,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache();
             return getStringElementFromCache(
                     (interaction) -> interaction.getResponse().getHeaders().values().toArray()[n].toString(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -581,7 +582,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getRequest().getMethod(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -637,7 +638,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return getIntegerElementFromCache((interaction) -> interaction.getResponse().getStatus().getCode(), 0);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -664,7 +665,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getResponse().getStatus().getMessage(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -817,7 +818,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
                 throw new IllegalStateException("Could not load URL from cache");
             }
             return new URL(urlString);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException | MalformedURLException e) {
             throw new RuntimeException(e);
         }
     }
@@ -879,7 +880,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getResponse().getHeaders().get(name).get(0),
                     null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -905,7 +906,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
                 return Collections.emptyMap();
             }
             return cachedInteraction.getResponse().getHeaders();
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -964,7 +965,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return getObjectElementFromCache((interaction) -> interaction.getResponse().getBody(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -1241,7 +1242,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getRequest().getHeaders().get(key).toString(),
                     null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -1272,7 +1273,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return createInputStream(this.cachedInteraction.getResponse().getBody());
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
@@ -3,8 +3,11 @@ package com.easypost.easyvcr.clients.httpurlconnection;
 import com.easypost.easyvcr.AdvancedSettings;
 import com.easypost.easyvcr.Cassette;
 import com.easypost.easyvcr.Mode;
+import com.easypost.easyvcr.RecordingExpirationException;
 import com.easypost.easyvcr.VCRException;
 import com.easypost.easyvcr.interactionconverters.HttpUrlConnectionInteractionConverter;
+import com.easypost.easyvcr.internalutilities.ConsoleFallbackLogger;
+import com.easypost.easyvcr.internalutilities.ExpirationActionExtensions;
 import com.easypost.easyvcr.requestelements.HttpInteraction;
 import com.easypost.easyvcr.requestelements.Request;
 
@@ -13,7 +16,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpRetryException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.SocketPermission;
@@ -66,6 +68,11 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
     private HttpInteraction cachedInteraction;
 
     /**
+     * Logger to use for logging (uses custom logger internally if set, otherwise logs to console).
+     */
+    private final ConsoleFallbackLogger logger;
+
+    /**
      * Constructor for the RecordableHttpURLConnection class.
      *
      * @param url              The URL to connect to.
@@ -76,7 +83,8 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
      * @throws IOException If an error occurs.
      */
     public RecordableHttpURLConnection(URL url, Proxy proxy, Cassette cassette, Mode mode,
-                                       AdvancedSettings advancedSettings) throws IOException {
+                                       AdvancedSettings advancedSettings)
+            throws IOException, RecordingExpirationException {
         // this super is not used
         super(url);
         if (proxy == null) {
@@ -90,6 +98,8 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         this.mode = mode;
         this.advancedSettings = advancedSettings;
         this.converter = new HttpUrlConnectionInteractionConverter();
+        this.logger = new ConsoleFallbackLogger(advancedSettings.logger, "EasyVCR");
+        ExpirationActionExtensions.checkCompatibleSettings(advancedSettings.whenExpired, mode);
     }
 
     /**
@@ -102,7 +112,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
      * @throws IOException If an error occurs.
      */
     public RecordableHttpURLConnection(URL url, Cassette cassette, Mode mode, AdvancedSettings advancedSettings)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         this(url, null, cassette, mode, advancedSettings);
     }
 
@@ -115,7 +125,8 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
      * @param mode     The mode to use.
      * @throws IOException If an error occurs.
      */
-    public RecordableHttpURLConnection(URL url, Proxy proxy, Cassette cassette, Mode mode) throws IOException {
+    public RecordableHttpURLConnection(URL url, Proxy proxy, Cassette cassette, Mode mode)
+            throws IOException, RecordingExpirationException {
         this(url, proxy, cassette, mode, new AdvancedSettings());
     }
 
@@ -127,7 +138,8 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
      * @param mode     The mode to use.
      * @throws IOException If an error occurs.
      */
-    public RecordableHttpURLConnection(URL url, Cassette cassette, Mode mode) throws IOException {
+    public RecordableHttpURLConnection(URL url, Cassette cassette, Mode mode)
+            throws IOException, RecordingExpirationException {
         this(url, cassette, mode, new AdvancedSettings());
     }
 
@@ -217,7 +229,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
      * @throws VCRException         If an error occurs.
      * @throws InterruptedException If the thread is interrupted.
      */
-    private boolean loadExistingInteraction() throws VCRException, InterruptedException {
+    private boolean loadExistingInteraction() throws VCRException, RecordingExpirationException, InterruptedException {
         Request request =
                 converter.createRecordedRequest(this.connection, this.requestBody, this.advancedSettings.censors);
         // null because couldn't be created
@@ -229,6 +241,45 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         if (matchingInteraction == null) {
             return false;
         }
+
+        // check the recording's expiration
+        if (advancedSettings.timeFrame.hasLapsed(matchingInteraction.getRecordedAt())) {
+            // recording has expired
+            switch (mode) {
+                case Replay:
+                    switch (advancedSettings.whenExpired) {
+                        case Warn:
+                            this.logger.warning("Matching interaction is expired.");
+                            break;
+                        case Throw_Exception:
+                            throw new RecordingExpirationException("Matching interaction is expired.");
+                        case Record_Again:
+                            // we should never get here, but just in case.
+                            throw new RecordingExpirationException(
+                                    "Cannot use the Record_Again expiration action in combination with Replay mode.");
+                        default:
+                            break;
+                    }
+                    break;
+                case Auto:
+                    switch (advancedSettings.whenExpired) {
+                        case Warn:
+                            this.logger.warning("Matching interaction is expired.");
+                            break;
+                        case Throw_Exception:
+                            throw new RecordingExpirationException("Matching interaction is expired.");
+                        case Record_Again:
+                            // will trigger a re-recording of the interaction
+                            return false;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
         simulateDelay(matchingInteraction, this.advancedSettings);
         this.cachedInteraction = matchingInteraction;
         this.cachedInteraction.getResponse().addReplayHeaders();
@@ -240,7 +291,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
      *
      * @throws VCRException If an error occurs.
      */
-    private void buildCache() throws VCRException {
+    private void buildCache() throws VCRException, RecordingExpirationException {
         // run every time a user attempts to getX()
 
         // can't setX() after the first getX(), so if cache has already been built, can't build again
@@ -256,6 +307,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
                 try {
                     loadExistingInteraction();
                 } catch (VCRException | InterruptedException e) {
+                    // does not catch RecordingExpirationException, so that exception will make it through
                     throw new RuntimeException(e);
                 }
                 break;
@@ -265,6 +317,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
                         cacheInteraction(true);
                     }
                 } catch (VCRException | InterruptedException e) {
+                    // does not catch RecordingExpirationException, so that exception will make it through
                     throw new RuntimeException(e);
                 }
                 break;
@@ -305,7 +358,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache(); // can't set anything after connecting, so might as well build the cache now
             // will establish connection as a result of caching, so need to disconnect afterwards
             this.connection.disconnect();
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -341,7 +394,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache();
             return getStringElementFromCache(
                     (interaction) -> interaction.getResponse().getHeaders().keySet().toArray()[n].toString(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -473,7 +526,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache();
             return getStringElementFromCache(
                     (interaction) -> interaction.getResponse().getHeaders().values().toArray()[n].toString(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -528,7 +581,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getRequest().getMethod(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -584,7 +637,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return getIntegerElementFromCache((interaction) -> interaction.getResponse().getStatus().getCode(), 0);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -611,7 +664,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getResponse().getStatus().getMessage(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -764,7 +817,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
                 throw new IllegalStateException("Could not load URL from cache");
             }
             return new URL(urlString);
-        } catch (VCRException | MalformedURLException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -826,7 +879,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getResponse().getHeaders().get(name).get(0),
                     null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -852,7 +905,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
                 return Collections.emptyMap();
             }
             return cachedInteraction.getResponse().getHeaders();
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -911,7 +964,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return getObjectElementFromCache((interaction) -> interaction.getResponse().getBody(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -1188,7 +1241,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getRequest().getHeaders().get(key).toString(),
                     null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -1219,7 +1272,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
             return createInputStream(this.cachedInteraction.getResponse().getBody());
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -1358,7 +1411,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
      * @since 1.3
      */
     @Override
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings ("rawtypes")
     public Object getContent(Class[] classes) throws IOException {
         // not in cassette, go to real connection
         return this.connection.getContent(classes);

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
@@ -257,9 +257,9 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
                         case Warn:
                             this.logger.warning("Matching interaction is expired.");
                             break;
-                        case Throw_Exception:
+                        case ThrowException:
                             throw new RecordingExpirationException("Matching interaction is expired.");
-                        case Record_Again:
+                        case RecordAgain:
                             // we should never get here, but just in case.
                             throw new RecordingExpirationException(
                                     "Cannot use the Record_Again expiration action in combination with Replay mode.");
@@ -272,9 +272,9 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
                         case Warn:
                             this.logger.warning("Matching interaction is expired.");
                             break;
-                        case Throw_Exception:
+                        case ThrowException:
                             throw new RecordingExpirationException("Matching interaction is expired.");
-                        case Record_Again:
+                        case RecordAgain:
                             // will trigger a re-recording of the interaction
                             return false;
                         default:

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
@@ -3,8 +3,11 @@ package com.easypost.easyvcr.clients.httpurlconnection;
 import com.easypost.easyvcr.AdvancedSettings;
 import com.easypost.easyvcr.Cassette;
 import com.easypost.easyvcr.Mode;
+import com.easypost.easyvcr.RecordingExpirationException;
 import com.easypost.easyvcr.VCRException;
 import com.easypost.easyvcr.interactionconverters.HttpUrlConnectionInteractionConverter;
+import com.easypost.easyvcr.internalutilities.ConsoleFallbackLogger;
+import com.easypost.easyvcr.internalutilities.ExpirationActionExtensions;
 import com.easypost.easyvcr.requestelements.HttpInteraction;
 import com.easypost.easyvcr.requestelements.Request;
 
@@ -16,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpRetryException;
-import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.SocketPermission;
@@ -71,6 +73,11 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
     private HttpInteraction cachedInteraction;
 
     /**
+     * Logger to use for logging (uses custom logger internally if set, otherwise logs to console).
+     */
+    private final ConsoleFallbackLogger logger;
+
+    /**
      * Constructor for the RecordableHttpsURLConnection class.
      *
      * @param url              The URL to connect to.
@@ -81,7 +88,8 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
      * @throws IOException If an error occurs.
      */
     public RecordableHttpsURLConnection(URL url, Proxy proxy, Cassette cassette, Mode mode,
-                                        AdvancedSettings advancedSettings) throws IOException {
+                                        AdvancedSettings advancedSettings)
+            throws IOException, RecordingExpirationException {
         // this super is not used
         super(url);
         if (proxy == null) {
@@ -95,6 +103,8 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         this.mode = mode;
         this.advancedSettings = advancedSettings;
         this.converter = new HttpUrlConnectionInteractionConverter();
+        this.logger = new ConsoleFallbackLogger(advancedSettings.logger, "EasyVCR");
+        ExpirationActionExtensions.checkCompatibleSettings(advancedSettings.whenExpired, mode);
     }
 
     /**
@@ -107,7 +117,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
      * @throws IOException If an error occurs.
      */
     public RecordableHttpsURLConnection(URL url, Cassette cassette, Mode mode, AdvancedSettings advancedSettings)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         this(url, null, cassette, mode, advancedSettings);
     }
 
@@ -120,7 +130,8 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
      * @param mode     The mode to use.
      * @throws IOException If an error occurs.
      */
-    public RecordableHttpsURLConnection(URL url, Proxy proxy, Cassette cassette, Mode mode) throws IOException {
+    public RecordableHttpsURLConnection(URL url, Proxy proxy, Cassette cassette, Mode mode)
+            throws IOException, RecordingExpirationException {
         this(url, proxy, cassette, mode, new AdvancedSettings());
     }
 
@@ -132,7 +143,8 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
      * @param mode     The mode to use.
      * @throws IOException If an error occurs.
      */
-    public RecordableHttpsURLConnection(URL url, Cassette cassette, Mode mode) throws IOException {
+    public RecordableHttpsURLConnection(URL url, Cassette cassette, Mode mode)
+            throws IOException, RecordingExpirationException {
         this(url, cassette, mode, new AdvancedSettings());
     }
 
@@ -222,7 +234,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
      * @throws VCRException         If an error occurs.
      * @throws InterruptedException If the thread is interrupted.
      */
-    private boolean loadExistingInteraction() throws VCRException, InterruptedException {
+    private boolean loadExistingInteraction() throws VCRException, RecordingExpirationException, InterruptedException {
         Request request =
                 converter.createRecordedRequest(this.connection, this.requestBody, this.advancedSettings.censors);
         // null because couldn't be created
@@ -234,6 +246,45 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         if (matchingInteraction == null) {
             return false;
         }
+
+        // check the recording's expiration
+        if (advancedSettings.timeFrame.hasLapsed(matchingInteraction.getRecordedAt())) {
+            // recording has expired
+            switch (mode) {
+                case Replay:
+                    switch (advancedSettings.whenExpired) {
+                        case Warn:
+                            this.logger.warning("Matching interaction is expired.");
+                            break;
+                        case Throw_Exception:
+                            throw new RecordingExpirationException("Matching interaction is expired.");
+                        case Record_Again:
+                            // we should never get here, but just in case.
+                            throw new RecordingExpirationException(
+                                    "Cannot use the Record_Again expiration action in combination with Replay mode.");
+                        default:
+                            break;
+                    }
+                    break;
+                case Auto:
+                    switch (advancedSettings.whenExpired) {
+                        case Warn:
+                            this.logger.warning("Matching interaction is expired.");
+                            break;
+                        case Throw_Exception:
+                            throw new RecordingExpirationException("Matching interaction is expired.");
+                        case Record_Again:
+                            // will trigger a re-recording of the interaction
+                            return false;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
         simulateDelay(matchingInteraction, this.advancedSettings);
         this.cachedInteraction = matchingInteraction;
         this.cachedInteraction.getResponse().addReplayHeaders();
@@ -245,7 +296,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
      *
      * @throws VCRException If an error occurs.
      */
-    private void buildCache() throws VCRException {
+    private void buildCache() throws VCRException, RecordingExpirationException {
         // run every time a user attempts to getX()
 
         // can't setX() after the first getX(), so if cache has already been built, can't build again
@@ -261,6 +312,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
                 try {
                     loadExistingInteraction();
                 } catch (VCRException | InterruptedException e) {
+                    // does not catch RecordingExpirationException, so that exception will make it through
                     throw new RuntimeException(e);
                 }
                 break;
@@ -270,6 +322,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
                         cacheInteraction(true);
                     }
                 } catch (VCRException | InterruptedException e) {
+                    // does not catch RecordingExpirationException, so that exception will make it through
                     throw new RuntimeException(e);
                 }
                 break;
@@ -308,7 +361,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache(); // can't set anything after connecting, so might as well build the cache now
             // will establish connection as a result of caching, so need to disconnect afterwards
             this.connection.disconnect();
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -344,7 +397,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache();
             return getStringElementFromCache(
                     (interaction) -> interaction.getResponse().getHeaders().keySet().toArray()[n].toString(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -476,7 +529,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache();
             return getStringElementFromCache(
                     (interaction) -> interaction.getResponse().getHeaders().values().toArray()[n].toString(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -531,7 +584,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getRequest().getMethod(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -587,7 +640,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return getIntegerElementFromCache((interaction) -> interaction.getResponse().getStatus().getCode(), 0);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -614,7 +667,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getResponse().getStatus().getMessage(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -767,7 +820,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
                 throw new IllegalStateException("Could not load URL from cache");
             }
             return new URL(urlString);
-        } catch (VCRException | MalformedURLException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -829,7 +882,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getResponse().getHeaders().get(name).get(0),
                     null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -855,7 +908,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
                 return Collections.emptyMap();
             }
             return cachedInteraction.getResponse().getHeaders();
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -914,7 +967,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return getObjectElementFromCache((interaction) -> interaction.getResponse().getBody(), null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -1191,7 +1244,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getRequest().getHeaders().get(key).toString(),
                     null);
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -1222,7 +1275,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return createInputStream(this.cachedInteraction.getResponse().getBody());
-        } catch (VCRException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -1361,7 +1414,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
      * @since 1.3
      */
     @Override
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings ("rawtypes")
     public Object getContent(Class[] classes) throws IOException {
         // not in cassette, go to real connection
         return this.connection.getContent(classes);

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpRetryException;
+import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.SocketPermission;
@@ -361,7 +362,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache(); // can't set anything after connecting, so might as well build the cache now
             // will establish connection as a result of caching, so need to disconnect afterwards
             this.connection.disconnect();
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -397,7 +398,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache();
             return getStringElementFromCache(
                     (interaction) -> interaction.getResponse().getHeaders().keySet().toArray()[n].toString(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -529,7 +530,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache();
             return getStringElementFromCache(
                     (interaction) -> interaction.getResponse().getHeaders().values().toArray()[n].toString(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -584,7 +585,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getRequest().getMethod(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -640,7 +641,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return getIntegerElementFromCache((interaction) -> interaction.getResponse().getStatus().getCode(), 0);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -667,7 +668,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getResponse().getStatus().getMessage(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -820,7 +821,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
                 throw new IllegalStateException("Could not load URL from cache");
             }
             return new URL(urlString);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException | MalformedURLException e) {
             throw new RuntimeException(e);
         }
     }
@@ -882,7 +883,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getResponse().getHeaders().get(name).get(0),
                     null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -908,7 +909,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
                 return Collections.emptyMap();
             }
             return cachedInteraction.getResponse().getHeaders();
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -967,7 +968,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return getObjectElementFromCache((interaction) -> interaction.getResponse().getBody(), null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -1244,7 +1245,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
             buildCache();
             return getStringElementFromCache((interaction) -> interaction.getRequest().getHeaders().get(key).toString(),
                     null);
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -1275,7 +1276,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
             return createInputStream(this.cachedInteraction.getResponse().getBody());
-        } catch (Exception e) {
+        } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableURL.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableURL.java
@@ -3,6 +3,7 @@ package com.easypost.easyvcr.clients.httpurlconnection;
 import com.easypost.easyvcr.AdvancedSettings;
 import com.easypost.easyvcr.Cassette;
 import com.easypost.easyvcr.Mode;
+import com.easypost.easyvcr.RecordingExpirationException;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -262,7 +263,7 @@ public final class RecordableURL {
      * @return a RecordableHttpURLConnection instance.
      * @throws IOException if an I/O error occurs.
      */
-    public RecordableHttpURLConnection openConnection() throws IOException {
+    public RecordableHttpURLConnection openConnection() throws IOException, RecordingExpirationException {
         return new RecordableHttpURLConnection(this.url, this.cassette, this.mode, this.advancedSettings);
     }
 
@@ -273,7 +274,7 @@ public final class RecordableURL {
      * @return a RecordableHttpURLConnection instance.
      * @throws IOException if an I/O error occurs.
      */
-    public RecordableHttpURLConnection openConnection(Proxy proxy) throws IOException {
+    public RecordableHttpURLConnection openConnection(Proxy proxy) throws IOException, RecordingExpirationException {
         return new RecordableHttpURLConnection(this.url, proxy, this.cassette, this.mode, this.advancedSettings);
     }
 
@@ -283,7 +284,7 @@ public final class RecordableURL {
      * @return a RecordableHttpsURLConnection instance.
      * @throws IOException if an I/O error occurs.
      */
-    public RecordableHttpsURLConnection openConnectionSecure() throws IOException {
+    public RecordableHttpsURLConnection openConnectionSecure() throws IOException, RecordingExpirationException {
         return new RecordableHttpsURLConnection(this.url, this.cassette, this.mode, this.advancedSettings);
     }
 
@@ -294,7 +295,8 @@ public final class RecordableURL {
      * @return a RecordableHttpsURLConnection instance.
      * @throws IOException if an I/O error occurs.
      */
-    public RecordableHttpsURLConnection openConnectionSecure(Proxy proxy) throws IOException {
+    public RecordableHttpsURLConnection openConnectionSecure(Proxy proxy)
+            throws IOException, RecordingExpirationException {
         return new RecordableHttpsURLConnection(this.url, proxy, this.cassette, this.mode, this.advancedSettings);
     }
 }

--- a/src/main/java/com/easypost/easyvcr/internalutilities/ConsoleFallbackLogger.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/ConsoleFallbackLogger.java
@@ -4,7 +4,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A logger that, if there's no proper logger, writes to the console instead.
+ * A logger wrapper that, if there's no proper internal logger, writes to the console instead.
  */
 public final class ConsoleFallbackLogger {
     private final Logger logger;

--- a/src/main/java/com/easypost/easyvcr/internalutilities/ConsoleFallbackLogger.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/ConsoleFallbackLogger.java
@@ -1,0 +1,53 @@
+package com.easypost.easyvcr.internalutilities;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A logger that, if there's no proper logger, writes to the console instead.
+ */
+public final class ConsoleFallbackLogger {
+    private final Logger logger;
+    private final String name;
+
+    /**
+     * Constructor for ConsoleFallbackLogger.
+     *
+     * @param logger {@link Logger} logger to optionally use internally.
+     * @param name   Name of the application.
+     */
+    public ConsoleFallbackLogger(Logger logger, String name) {
+        this.logger = logger;
+        this.name = name;
+    }
+
+    /**
+     * Logs an error message to the logger or console.
+     *
+     * @param message The message to log.
+     */
+    public void error(String message) {
+        if (logger != null) {
+            logger.log(Level.INFO, makeMessage(message));
+        } else {
+            System.err.println(makeMessage(message));
+        }
+    }
+
+    /**
+     * Logs a warning message to the logger or console.
+     *
+     * @param message The message to log.
+     */
+    public void warning(String message) {
+        if (logger != null) {
+            logger.log(Level.WARNING, makeMessage(message));
+        } else {
+            System.out.println(makeMessage(message));
+        }
+    }
+
+    private String makeMessage(String message) {
+        return name + ": " + message;
+    }
+}

--- a/src/main/java/com/easypost/easyvcr/internalutilities/ExpirationActionExtensions.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/ExpirationActionExtensions.java
@@ -1,0 +1,22 @@
+package com.easypost.easyvcr.internalutilities;
+
+import com.easypost.easyvcr.ExpirationActions;
+import com.easypost.easyvcr.Mode;
+import com.easypost.easyvcr.RecordingExpirationException;
+
+public abstract class ExpirationActionExtensions {
+    /**
+     * Check if the expiration action is valid for the given mode.
+     *
+     * @param action ExpirationAction to check.
+     * @param mode   Mode to check.
+     * @throws RecordingExpirationException If the action is not valid for the given mode.
+     */
+    public static void checkCompatibleSettings(ExpirationActions action, Mode mode)
+            throws RecordingExpirationException {
+        if (action == ExpirationActions.Record_Again && mode == Mode.Replay) {
+            throw new RecordingExpirationException(
+                    "Cannot use the Record_Again expiration action in combination with Replay mode.");
+        }
+    }
+}

--- a/src/main/java/com/easypost/easyvcr/internalutilities/ExpirationActionExtensions.java
+++ b/src/main/java/com/easypost/easyvcr/internalutilities/ExpirationActionExtensions.java
@@ -14,7 +14,7 @@ public abstract class ExpirationActionExtensions {
      */
     public static void checkCompatibleSettings(ExpirationActions action, Mode mode)
             throws RecordingExpirationException {
-        if (action == ExpirationActions.Record_Again && mode == Mode.Replay) {
+        if (action == ExpirationActions.RecordAgain && mode == Mode.Replay) {
             throw new RecordingExpirationException(
                     "Cannot use the Record_Again expiration action in combination with Replay mode.");
         }

--- a/src/test/java/HttpUrlConnectionTest.java
+++ b/src/test/java/HttpUrlConnectionTest.java
@@ -402,7 +402,7 @@ public class HttpUrlConnectionTest {
         // replay cassette with custom expiration rules, should not find a match because recording is expired (throw exception)
         AdvancedSettings advancedSettings = new AdvancedSettings();
         advancedSettings.timeFrame = TimeFrame.never();
-        advancedSettings.whenExpired = ExpirationActions.Throw_Exception;  // throw exception when recording is expired
+        advancedSettings.whenExpired = ExpirationActions.ThrowException;  // throw exception when recording is expired
         Thread.sleep(1000); // allow 1 second to lapse to ensure recording is now "expired"
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
                 FakeDataService.URL, cassette, Mode.Replay, advancedSettings);
@@ -414,7 +414,7 @@ public class HttpUrlConnectionTest {
         // replay cassette with bad expiration rules, should throw an exception because settings are bad
         advancedSettings = new AdvancedSettings();
         advancedSettings.timeFrame = TimeFrame.never();
-        advancedSettings.whenExpired = ExpirationActions.Record_Again;  // invalid settings for replay mode, should throw exception
+        advancedSettings.whenExpired = ExpirationActions.RecordAgain;  // invalid settings for replay mode, should throw exception
         AdvancedSettings finalAdvancedSettings = advancedSettings;
         Assert.assertThrows(RecordingExpirationException.class, () -> HttpClients.newClient(HttpClientType.HttpsUrlConnection,
                 FakeDataService.URL, cassette, Mode.Replay, finalAdvancedSettings));

--- a/src/test/java/TestUtils.java
+++ b/src/test/java/TestUtils.java
@@ -1,6 +1,7 @@
 import com.easypost.easyvcr.AdvancedSettings;
 import com.easypost.easyvcr.Cassette;
 import com.easypost.easyvcr.Mode;
+import com.easypost.easyvcr.RecordingExpirationException;
 import com.easypost.easyvcr.VCR;
 import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpURLConnection;
 import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpsURLConnection;
@@ -18,24 +19,24 @@ public class TestUtils {
     }
 
     public static RecordableHttpURLConnection getSimpleHttpURLConnection(String url, String cassetteName, Mode mode, AdvancedSettings advancedSettings)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         Cassette cassette = getCassette(cassetteName);
         return new RecordableURL(new URL(url), cassette, mode, advancedSettings).openConnection();
     }
 
     public static RecordableHttpURLConnection getSimpleHttpURLConnection(String cassetteName, Mode mode, AdvancedSettings advancedSettings)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         return getSimpleHttpURLConnection(FakeDataService.URL, cassetteName, mode, advancedSettings);
     }
 
     public static RecordableHttpsURLConnection getSimpleHttpsURLConnection(String url, String cassetteName, Mode mode, AdvancedSettings advancedSettings)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         Cassette cassette = getCassette(cassetteName);
         return new RecordableURL(new URL(url), cassette, mode, advancedSettings).openConnectionSecure();
     }
 
     public static RecordableHttpsURLConnection getSimpleHttpsURLConnection(String cassetteName, Mode mode, AdvancedSettings advancedSettings)
-            throws IOException {
+            throws IOException, RecordingExpirationException {
         return getSimpleHttpsURLConnection(FakeDataService.URL, cassetteName, mode, advancedSettings);
     }
 


### PR DESCRIPTION
Set expiration time for interactions (how long since it was recorded should an interaction be considered valid)
  - Can determine what to do if a matching interaction is considered invalid:
    - Warn the user, but proceed with the interaction
    - Throw an exception
    - Automatically re-record (cannot use this in `Replay` mode)

Users can pass in a logger to EasyVCR (will be used to log warnings for expiration; otherwise, log to console)