### PR TITLE
Speed up CI

### DIFF
--- a/src/test/java/FakeDataService.java
+++ b/src/test/java/FakeDataService.java
@@ -3,32 +3,21 @@ import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpURLConnectio
 import com.easypost.easyvcr.clients.httpurlconnection.RecordableHttpsURLConnection;
 import com.easypost.easyvcr.internalutilities.json.Serialization;
 
-import java.util.List;
-
 import static com.easypost.easyvcr.internalutilities.Tools.readFromInputStream;
 
 public class FakeDataService {
 
-    public class ExchangeRates {
-        public String code;
-        public String currency;
-        public List<Rate> rates;
-        public String table;
+    public class IPAddressData {
+        public String IPAddress;
     }
 
-    public class Rate {
-        public String effectiveDate;
-        public float mid;
-        public String no;
-    }
-
-    public static final String URL = "https://api.nbp.pl/api/exchangerates/rates/a/gbp/last/10/?format=json";
+    public static final String URL = "https://api.ipify.org/?format=json";
 
     private interface FakeDataServiceBaseInterface {
 
-        ExchangeRates getExchangeRates() throws Exception;
+        IPAddressData getIPAddressData() throws Exception;
 
-        Object getExchangeRatesRawResponse() throws Exception;
+        Object getIPAddressDataRawResponse() throws Exception;
     }
 
     public static class HttpUrlConnection extends FakeDataServiceBase implements FakeDataServiceBaseInterface {
@@ -52,15 +41,15 @@ public class FakeDataService {
         }
 
         @Override
-        public ExchangeRates getExchangeRates() throws Exception {
-            RecordableHttpURLConnection client = (RecordableHttpURLConnection) getExchangeRatesRawResponse();
+        public IPAddressData getIPAddressData() throws Exception {
+            RecordableHttpURLConnection client = (RecordableHttpURLConnection) getIPAddressDataRawResponse();
             String json = readFromInputStream(client.getInputStream());
 
-            return Serialization.convertJsonToObject(json, ExchangeRates.class);
+            return Serialization.convertJsonToObject(json, IPAddressData.class);
         }
 
         @Override
-        public Object getExchangeRatesRawResponse() throws Exception {
+        public Object getIPAddressDataRawResponse() throws Exception {
             RecordableHttpURLConnection client = getClient(URL);
             client.connect();
             return client;
@@ -88,15 +77,15 @@ public class FakeDataService {
         }
 
         @Override
-        public ExchangeRates getExchangeRates() throws Exception {
-            RecordableHttpsURLConnection client = (RecordableHttpsURLConnection) getExchangeRatesRawResponse();
+        public IPAddressData getIPAddressData() throws Exception {
+            RecordableHttpsURLConnection client = (RecordableHttpsURLConnection) getIPAddressDataRawResponse();
             String json = readFromInputStream(client.getInputStream());
 
-            return Serialization.convertJsonToObject(json, ExchangeRates.class);
+            return Serialization.convertJsonToObject(json, IPAddressData.class);
         }
 
         @Override
-        public Object getExchangeRatesRawResponse() throws Exception {
+        public Object getIPAddressDataRawResponse() throws Exception {
             RecordableHttpsURLConnection client = getClient(URL);
             client.connect();
             return client;

--- a/src/test/java/HttpUrlConnectionTest.java
+++ b/src/test/java/HttpUrlConnectionTest.java
@@ -27,12 +27,12 @@ import static com.easypost.easyvcr.internalutilities.Tools.readFromInputStream;
 
 public class HttpUrlConnectionTest {
 
-    private static FakeDataService.ExchangeRates GetExchangeRatesRequest(Cassette cassette, Mode mode) throws Exception {
+    private static FakeDataService.IPAddressData getIPAddressDataRequest(Cassette cassette, Mode mode) throws Exception {
         RecordableHttpsURLConnection connection = TestUtils.getSimpleHttpsURLConnection(cassette.name, mode, null);
 
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
 
-        return fakeDataService.getExchangeRates();
+        return fakeDataService.getIPAddressData();
     }
 
     @Test
@@ -107,7 +107,7 @@ public class HttpUrlConnectionTest {
         Cassette cassette = TestUtils.getCassette("test_erase");
 
         // record something to the cassette
-        GetExchangeRatesRequest(cassette, Mode.Record);
+        getIPAddressDataRequest(cassette, Mode.Record);
         Assert.assertTrue(cassette.numInteractions() > 0);
 
         // erase the cassette
@@ -120,9 +120,9 @@ public class HttpUrlConnectionTest {
         Cassette cassette = TestUtils.getCassette("test_erase_and_record");
         cassette.erase(); // Erase cassette before recording
 
-        FakeDataService.ExchangeRates exchangeRates = GetExchangeRatesRequest(cassette, Mode.Record);
+        FakeDataService.IPAddressData summary = getIPAddressDataRequest(cassette, Mode.Record);
 
-        Assert.assertNotNull(exchangeRates);
+        Assert.assertNotNull(summary);
         Assert.assertTrue(cassette.numInteractions() > 0); // Make sure cassette is not empty
     }
 
@@ -132,7 +132,7 @@ public class HttpUrlConnectionTest {
         cassette.erase(); // Erase cassette before recording
 
         // cassette is empty, so replaying should throw an exception
-        Assert.assertThrows(Exception.class, () -> GetExchangeRatesRequest(cassette, Mode.Replay));
+        Assert.assertThrows(Exception.class, () -> getIPAddressDataRequest(cassette, Mode.Replay));
     }
 
     @Test
@@ -141,12 +141,12 @@ public class HttpUrlConnectionTest {
         cassette.erase(); // Erase cassette before recording
 
         // in replay mode, if cassette is empty, should throw an exception
-        Assert.assertThrows(Exception.class, () -> GetExchangeRatesRequest(cassette, Mode.Replay));
+        Assert.assertThrows(Exception.class, () -> getIPAddressDataRequest(cassette, Mode.Replay));
         Assert.assertEquals(cassette.numInteractions(), 0); // Make sure cassette is still empty
 
         // in auto mode, if cassette is empty, should make and record a real request
-        FakeDataService.ExchangeRates exchangeRates = GetExchangeRatesRequest(cassette, Mode.Auto);
-        Assert.assertNotNull(exchangeRates);
+        FakeDataService.IPAddressData summary = getIPAddressDataRequest(cassette, Mode.Auto);
+        Assert.assertNotNull(summary);
         Assert.assertTrue(cassette.numInteractions() > 0); // Make sure cassette is no longer empty
     }
 
@@ -162,7 +162,7 @@ public class HttpUrlConnectionTest {
 
         // Most elements of a VCR request are black-boxed, so we can't test them here.
         // Instead, we can get the recreated HttpResponseMessage and check the details.
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getIPAddressDataRawResponse();
         Assert.assertNotNull(response);
     }
 
@@ -185,13 +185,13 @@ public class HttpUrlConnectionTest {
                 (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
                         FakeDataService.URL, cassette, Mode.Record, advancedSettings);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        fakeDataService.getExchangeRatesRawResponse();
+        fakeDataService.getIPAddressDataRawResponse();
 
         // now replay cassette
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
                 FakeDataService.URL, cassette, Mode.Replay, advancedSettings);
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getIPAddressDataRawResponse();
 
         // check that the replayed response contains the censored header
         Assert.assertNotNull(response);
@@ -211,7 +211,7 @@ public class HttpUrlConnectionTest {
                 (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
                         FakeDataService.URL, cassette, Mode.Record);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        fakeDataService.getExchangeRatesRawResponse();
+        fakeDataService.getIPAddressDataRawResponse();
 
         // replay cassette with default match rules, should find a match
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
@@ -219,7 +219,7 @@ public class HttpUrlConnectionTest {
         connection.setRequestProperty("X-Custom-Header",
                 "custom-value"); // add custom header to request, shouldn't matter when matching by default rules
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getIPAddressDataRawResponse();
         Assert.assertNotNull(response);
 
         // replay cassette with custom match rules, should not find a match because request is different (throw exception)
@@ -233,7 +233,7 @@ public class HttpUrlConnectionTest {
                 "custom-value"); // add custom header to request, causing a match failure when matching by everything
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
         FakeDataService.HttpsUrlConnection finalFakeDataService = fakeDataService;
-        Assert.assertThrows(Exception.class, () -> finalFakeDataService.getExchangeRates());
+        Assert.assertThrows(Exception.class, () -> finalFakeDataService.getIPAddressData());
     }
 
     @Test
@@ -246,7 +246,7 @@ public class HttpUrlConnectionTest {
                 (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
                         FakeDataService.URL, cassette, Mode.Record);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        fakeDataService.getExchangeRatesRawResponse();
+        fakeDataService.getIPAddressDataRawResponse();
 
         // baseline - how much time does it take to replay the cassette?
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
@@ -254,11 +254,11 @@ public class HttpUrlConnectionTest {
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
 
         Instant start = Instant.now();
-        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
+        FakeDataService.IPAddressData summary = fakeDataService.getIPAddressData();
         Instant end = Instant.now();
 
         // confirm the normal replay worked, note time
-        Assert.assertNotNull(exchangeRates);
+        Assert.assertNotNull(summary);
         int normalReplayTime = (int) Duration.between(start, end).toMillis();
 
         // set up advanced settings
@@ -271,11 +271,11 @@ public class HttpUrlConnectionTest {
 
         // time replay request
         start = Instant.now();
-        exchangeRates = fakeDataService.getExchangeRates();
+        summary = fakeDataService.getIPAddressData();
         end = Instant.now();
 
         // check that the delay was respected
-        Assert.assertNotNull(exchangeRates);
+        Assert.assertNotNull(summary);
         Assert.assertTrue((int) Duration.between(start, end).toMillis() >= delay);
     }
 
@@ -390,13 +390,13 @@ public class HttpUrlConnectionTest {
                 (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
                         FakeDataService.URL, cassette, Mode.Record);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        fakeDataService.getExchangeRatesRawResponse();
+        fakeDataService.getIPAddressDataRawResponse();
 
         // replay cassette with default expiration rules, should find a match
         connection = (RecordableHttpsURLConnection) HttpClients.newClient(HttpClientType.HttpsUrlConnection,
                 FakeDataService.URL, cassette, Mode.Replay);
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getIPAddressDataRawResponse();
         Assert.assertNotNull(response);
 
         // replay cassette with custom expiration rules, should not find a match because recording is expired (throw exception)
@@ -409,7 +409,7 @@ public class HttpUrlConnectionTest {
         fakeDataService = new FakeDataService.HttpsUrlConnection(connection);
         FakeDataService.HttpsUrlConnection finalFakeDataService = fakeDataService;
         // this throws a RuntimeException rather than a RecordingExpirationException because the exceptions are coalesced internally
-        Assert.assertThrows(Exception.class, () -> finalFakeDataService.getExchangeRates());
+        Assert.assertThrows(Exception.class, () -> finalFakeDataService.getIPAddressData());
 
         // replay cassette with bad expiration rules, should throw an exception because settings are bad
         advancedSettings = new AdvancedSettings();

--- a/src/test/java/VCRTest.java
+++ b/src/test/java/VCRTest.java
@@ -77,8 +77,8 @@ public class VCRTest {
 
         // record a request to a cassette
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(vcr);
-        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
-        Assert.assertNotNull(exchangeRates);
+        FakeDataService.IPAddressData summary = fakeDataService.getIPAddressData();
+        Assert.assertNotNull(summary);
         Assert.assertTrue(cassette.numInteractions() > 0);
 
         // erase the cassette
@@ -107,8 +107,8 @@ public class VCRTest {
         vcr.insert(cassette);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(vcr);
 
-        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
-        Assert.assertNotNull(exchangeRates);
+        FakeDataService.IPAddressData summary = fakeDataService.getIPAddressData();
+        Assert.assertNotNull(summary);
     }
 
     @Test
@@ -118,8 +118,8 @@ public class VCRTest {
         vcr.insert(cassette);
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(vcr);
 
-        FakeDataService.ExchangeRates exchangeRates = fakeDataService.getExchangeRates();
-        Assert.assertNotNull(exchangeRates);
+        FakeDataService.IPAddressData summary = fakeDataService.getIPAddressData();
+        Assert.assertNotNull(summary);
         Assert.assertTrue(cassette.numInteractions() > 0);
     }
 
@@ -131,14 +131,14 @@ public class VCRTest {
         FakeDataService.HttpsUrlConnection fakeDataService = new FakeDataService.HttpsUrlConnection(vcr);
 
         // record first
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getIPAddressDataRawResponse();
         Assert.assertTrue(cassette.numInteractions() > 0); // make sure we recorded something
         // check that the response did not come from a recorded cassette
         Assert.assertFalse(Utilities.responseCameFromRecording(response));
 
         // now replay
         vcr.replay();
-        response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
+        response = (RecordableHttpsURLConnection) fakeDataService.getIPAddressDataRawResponse();
         Assert.assertNotNull(response);
         // check that the response came from a recorded cassette
         Assert.assertTrue(Utilities.responseCameFromRecording(response));
@@ -146,7 +146,7 @@ public class VCRTest {
         // double check by erasing the cassette and trying to replay
         vcr.erase();
         // should throw an exception because there's no matching interaction now
-        Assert.assertThrows(Exception.class, fakeDataService::getExchangeRates);
+        Assert.assertThrows(Exception.class, fakeDataService::getIPAddressData);
     }
 
     @Test
@@ -189,7 +189,7 @@ public class VCRTest {
         RecordableURL client = vcr.getHttpUrlConnection(FakeDataService.URL);
         FakeDataService.HttpsUrlConnection fakeDataService =
                 new FakeDataService.HttpsUrlConnection(client.openConnectionSecure());
-        fakeDataService.getExchangeRates();
+        fakeDataService.getIPAddressData();
 
         // now replay and confirm that the censor is applied
         vcr.replay();
@@ -197,7 +197,7 @@ public class VCRTest {
         // so, we need to re-grab the VCR client and re-create the FakeDataService
         client = vcr.getHttpUrlConnection(FakeDataService.URL);
         fakeDataService = new FakeDataService.HttpsUrlConnection(client.openConnectionSecure());
-        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getExchangeRatesRawResponse();
+        RecordableHttpsURLConnection response = (RecordableHttpsURLConnection) fakeDataService.getIPAddressDataRawResponse();
 
         // check that the censor is applied
         Assert.assertNotNull(response);


### PR DESCRIPTION
Switched from the National Bank of Poland to [Ipify](https://api.ipify.org/?format=json) for the API to test against. You would think a National Bank could handle high-ish traffic on their API, unless we were perhaps triggering some DDoS protection?

Ipify offers an XML version of their API (few APIs seemed to do this nowadays, it's either this or Reddit in terms of "guaranteed to  keep existing" APIs). But the XML data seems off, and likely will fail when we actually need to utilize it for testing (currently, since XML handling is incomplete in EasyVCR, the unit tests for XML are disabled). So we'll punt on this for now.


Comparisons:
Java 8: [Old](https://github.com/EasyPost/easyvcr-java/runs/7418446726?check_suite_focus=true#step:4:1652) | [New](https://github.com/EasyPost/easyvcr-java/runs/7437081718?check_suite_focus=true#step:4:1652) (significantly faster)
Java 11: [Old](https://github.com/EasyPost/easyvcr-java/runs/7418447004?check_suite_focus=true#step:4:1666) | [New](https://github.com/EasyPost/easyvcr-java/runs/7437082097?check_suite_focus=true#step:4:1666) (faster)
Java 17: [Old](https://github.com/EasyPost/easyvcr-java/runs/7418447494?check_suite_focus=true#step:4:1666) | [New](https://github.com/EasyPost/easyvcr-java/runs/7437082717?check_suite_focus=true#step:4:1666) (faster)