### PR TITLE
Improve error handling, fix base URL comparison bug

### DIFF
--- a/src/main/java/com/easypost/easyvcr/MatchRules.java
+++ b/src/main/java/com/easypost/easyvcr/MatchRules.java
@@ -58,8 +58,13 @@ public final class MatchRules {
         return this;
     }
 
+    /**
+     * Extract the base URL from a URI.
+     *
+     * @param url The URI to extract the base URL from.
+     * @return The base URL.
+     */
     private static String getBaseUrl(URI url) {
-
         String baseUrl = url.getScheme() + "://" + url.getHost();
         if (url.getPort() != -1) {
             baseUrl += ":" + url.getPort();

--- a/src/main/java/com/easypost/easyvcr/MatchRules.java
+++ b/src/main/java/com/easypost/easyvcr/MatchRules.java
@@ -3,6 +3,7 @@ package com.easypost.easyvcr;
 import com.easypost.easyvcr.internal.Utilities;
 import com.easypost.easyvcr.requestelements.Request;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,11 +51,23 @@ public final class MatchRules {
      */
     public MatchRules byBaseUrl() {
         by((received, recorded) -> {
-            String receivedUri = received.getUri().getPath();
-            String recordedUri = recorded.getUri().getPath();
+            String receivedUri = getBaseUrl(received.getUri());
+            String recordedUri = getBaseUrl(recorded.getUri());
             return receivedUri.equalsIgnoreCase(recordedUri);
         });
         return this;
+    }
+
+    private static String getBaseUrl(URI url) {
+
+        String baseUrl = url.getScheme() + "://" + url.getHost();
+        if (url.getPort() != -1) {
+            baseUrl += ":" + url.getPort();
+        }
+        if (url.getPath() != null) {
+            baseUrl += url.getPath();
+        }
+        return baseUrl;
     }
 
     /**

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
@@ -144,6 +144,11 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         this(url, cassette, mode, new AdvancedSettings());
     }
 
+    /**
+     * Throws an exception if a matching interaction has not been cached.
+     *
+     * @throws VCRException If the interaction has not been cached.
+     */
     private void cachedInteractionExistsOtherwiseError() throws VCRException {
         if (this.cachedInteraction == null) {
             throw new VCRException("No matching interaction found.");

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
@@ -145,7 +145,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
     }
 
     private void cachedInteractionExistsOtherwiseError() throws VCRException {
-        if (this.cachedInteraction != null) {
+        if (this.cachedInteraction == null) {
             throw new VCRException("No matching interaction found.");
         }
     }

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpURLConnection.java
@@ -144,6 +144,12 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         this(url, cassette, mode, new AdvancedSettings());
     }
 
+    private void cachedInteractionExistsOtherwiseError() throws VCRException {
+        if (this.cachedInteraction != null) {
+            throw new VCRException("No matching interaction found.");
+        }
+    }
+
     /**
      * Get an object from the cache.
      *
@@ -725,6 +731,8 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         try {
             buildCache();
 
+            cachedInteractionExistsOtherwiseError();
+
             if (this.cachedInteraction.getResponse().getStatus().getCode() >= 400) {
                 // Client Error 4xx and Server Error 5xx
                 return createInputStream(this.cachedInteraction.getResponse().getBody());
@@ -1297,6 +1305,7 @@ public final class RecordableHttpURLConnection extends HttpURLConnection {
         }
         try {
             buildCache();
+            cachedInteractionExistsOtherwiseError();
             return createInputStream(this.cachedInteraction.getResponse().getBody());
         } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
@@ -150,7 +150,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
     }
 
     private void cachedInteractionExistsOtherwiseError() throws VCRException {
-        if (this.cachedInteraction != null) {
+        if (this.cachedInteraction == null) {
             throw new VCRException("No matching interaction found.");
         }
     }

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
@@ -149,6 +149,12 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         this(url, cassette, mode, new AdvancedSettings());
     }
 
+    private void cachedInteractionExistsOtherwiseError() throws VCRException {
+        if (this.cachedInteraction != null) {
+            throw new VCRException("No matching interaction found.");
+        }
+    }
+
     /**
      * Get an object from the cache.
      *
@@ -728,6 +734,8 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         try {
             buildCache();
 
+            cachedInteractionExistsOtherwiseError();
+
             if (this.cachedInteraction.getResponse().getStatus().getCode() >= 400) {
                 // Client Error 4xx and Server Error 5xx
                 return createInputStream(this.cachedInteraction.getResponse().getBody());
@@ -1300,6 +1308,7 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         }
         try {
             buildCache();
+            cachedInteractionExistsOtherwiseError();
             return createInputStream(this.cachedInteraction.getResponse().getBody());
         } catch (VCRException | RecordingExpirationException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
+++ b/src/main/java/com/easypost/easyvcr/clients/httpurlconnection/RecordableHttpsURLConnection.java
@@ -149,6 +149,11 @@ public final class RecordableHttpsURLConnection extends HttpsURLConnection {
         this(url, cassette, mode, new AdvancedSettings());
     }
 
+    /**
+     * Throws an exception if a matching interaction has not been cached.
+     *
+     * @throws VCRException If the interaction has not been cached.
+     */
     private void cachedInteractionExistsOtherwiseError() throws VCRException {
         if (this.cachedInteraction == null) {
             throw new VCRException("No matching interaction found.");

--- a/src/test/java/HttpUrlConnectionTest.java
+++ b/src/test/java/HttpUrlConnectionTest.java
@@ -560,8 +560,17 @@ public class HttpUrlConnectionTest {
                 url + "1", cassette, Mode.Replay, advancedSettings);
         // make HTTP call (attempt replay from cassette)
         connection.connect();
+
         // Attempt to pull data (e.g. body) from the response (via the input stream)
         // this throws a RuntimeException because of the way the exceptions are coalesced internally
-        Assert.assertThrows(RuntimeException.class, connection::getInputStream);
+        try {
+            connection.getInputStream();
+            // if we get here, the exception was not thrown as expected
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof RuntimeException);
+            Assert.assertTrue(e.getCause() instanceof VCRException);
+            Assert.assertEquals(e.getCause().getMessage(), "No matching interaction found.");
+        }
     }
 }


### PR DESCRIPTION
No more ambiguous NullPointerException when there's no matching recording in a cassette. Instead it's a RuntimeException (due to how the exceptions are coalesced internally) wrapping a VCRException, with a human-readable error message.

Before:
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/17054780/227369645-83ca68a8-afa6-4b12-af70-660044dbaede.png">

After:
<img width="769" alt="image" src="https://user-images.githubusercontent.com/17054780/227369130-39f4566d-6207-4b9d-8b96-c2554c39a3c2.png">


Fixes a bug that was comparing the wrong data when matching by base URLs