### PR TITLE
[feat] Add ability for users to define their own match rule(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- New `byCustomRule` function to allow users to define their own matching rule when finding a matching interaction in a cassette
 - Improve error messages when a matching interaction is not found (human-readable error messages)
 - Fix bug where the base URL matching rule was not comparing the scheme, host, and port of the request URL properly
 

--- a/src/main/java/com/easypost/easyvcr/MatchRules.java
+++ b/src/main/java/com/easypost/easyvcr/MatchRules.java
@@ -249,6 +249,18 @@ public final class MatchRules {
     }
 
     /**
+     * Add a rule to compare two requests by a custom rule.
+     * @param rule A BiFunction that accepts two Request instances and returns true if they match, false otherwise.
+     *             The first parameter is the current in-flight request,
+     *             the second parameter is the recorded request from the current cassette.
+     * @return This MatchRules factory.
+     */
+    public MatchRules byCustomRule(BiFunction<Request, Request, Boolean> rule) {
+        by(rule);
+        return this;
+    }
+
+    /**
      * Execute rules to determine if the received request matches the recorded request.
      *
      * @param receivedRequest Request to find a match for.


### PR DESCRIPTION
New `byCustomRule()` function allows users to define their own matching rules for finding recorded requests in a cassette