### PR TITLE
chore: update CODEOWNERS to use dev-tools team instead of team-shippers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 ## These are the standard rules for all EasyPost public repositories.
 ##
 
-* @EasyPost/team-shippers @EasyPost/easypost-public-maintainers
+* @EasyPost/dev-tools @EasyPost/easypost-public-maintainers
 
 # The devtools team owns the codeowners file, this is for auditing purposes
 .github/CODEOWNERS @easypost/dev-tools


### PR DESCRIPTION
Updates the CODEOWNERS file to use the dev-tools team instead of the team-shippers team.